### PR TITLE
Add http daemon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "resolved": "https://registry.npmjs.org/@nodeutils/defaults-deep/-/defaults-deep-1.1.0.tgz",
       "integrity": "sha1-uxEk3I184LxdodZorOWBSSWO8gs=",
       "requires": {
-        "lodash": "^4.15.0"
+        "lodash": "4.17.10"
       }
     },
     "@sindresorhus/is": {
@@ -22,7 +22,7 @@
       "resolved": "https://registry.npmjs.org/File/-/File-0.10.2.tgz",
       "integrity": "sha1-6Jn3dtJz4iQ7qGEFuzsFbQ+5VgQ=",
       "requires": {
-        "mime": ">= 0.0.0"
+        "mime": "2.3.1"
       }
     },
     "FileList": {
@@ -35,7 +35,7 @@
       "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
       "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
       "requires": {
-        "xtend": "~4.0.0"
+        "xtend": "4.0.1"
       }
     },
     "accept": {
@@ -43,8 +43,8 @@
       "resolved": "https://registry.npmjs.org/accept/-/accept-2.1.4.tgz",
       "integrity": "sha1-iHr1TO7lx/RDBGGXHsQAxh0JrLs=",
       "requires": {
-        "boom": "5.x.x",
-        "hoek": "4.x.x"
+        "boom": "5.2.0",
+        "hoek": "4.2.1"
       },
       "dependencies": {
         "boom": {
@@ -52,7 +52,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "4.2.1"
           }
         },
         "hoek": {
@@ -67,7 +67,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "requires": {
-        "mime-types": "~2.1.18",
+        "mime-types": "2.1.19",
         "negotiator": "0.6.1"
       }
     },
@@ -81,8 +81,8 @@
       "resolved": "https://registry.npmjs.org/ammo/-/ammo-2.0.4.tgz",
       "integrity": "sha1-v4CqshFpjqePY+9efxE91dnokX8=",
       "requires": {
-        "boom": "5.x.x",
-        "hoek": "4.x.x"
+        "boom": "5.2.0",
+        "hoek": "4.2.1"
       },
       "dependencies": {
         "boom": {
@@ -90,7 +90,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "4.2.1"
           }
         },
         "hoek": {
@@ -105,7 +105,7 @@
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
       "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
       "requires": {
-        "string-width": "^2.0.0"
+        "string-width": "2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -123,8 +123,8 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -132,7 +132,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -147,7 +147,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "requires": {
-        "color-convert": "^1.9.0"
+        "color-convert": "1.9.2"
       }
     },
     "aproba": {
@@ -160,8 +160,8 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.6"
       }
     },
     "arraybuffer.slice": {
@@ -174,9 +174,9 @@
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.0.1.tgz",
       "integrity": "sha512-aO8EaEgbgqq77IEw+1jfx5c9zTbzvkfuRBuZsSsPnTHMkmd5AI4J6OtITLZFa381jReeaQL67J0GBTUu0+ZTVw==",
       "requires": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "bn.js": "4.11.8",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1"
       }
     },
     "assert": {
@@ -192,7 +192,7 @@
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
       "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "requires": {
-        "lodash": "^4.17.10"
+        "lodash": "4.17.10"
       }
     },
     "async-limiter": {
@@ -220,7 +220,7 @@
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
       "integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "base32.js": {
@@ -286,7 +286,7 @@
       "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
       "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "bitcoin-ops": {
@@ -299,21 +299,21 @@
       "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-3.3.2.tgz",
       "integrity": "sha512-l5qqvbaK8wwtANPf6oEffykycg4383XgEYdia1rI7/JpGf1jfRWlOUCvx5TiTZS7kyIvY4j/UhIQ2urLsvGkzw==",
       "requires": {
-        "bech32": "^1.1.2",
-        "bigi": "^1.4.0",
-        "bip66": "^1.1.0",
-        "bitcoin-ops": "^1.3.0",
-        "bs58check": "^2.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.3",
-        "ecurve": "^1.0.0",
-        "merkle-lib": "^2.0.10",
-        "pushdata-bitcoin": "^1.0.1",
-        "randombytes": "^2.0.1",
-        "safe-buffer": "^5.0.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.0.4",
-        "wif": "^2.0.1"
+        "bech32": "1.1.3",
+        "bigi": "1.4.2",
+        "bip66": "1.1.5",
+        "bitcoin-ops": "1.4.1",
+        "bs58check": "2.1.1",
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "ecurve": "1.0.6",
+        "merkle-lib": "2.0.10",
+        "pushdata-bitcoin": "1.0.1",
+        "randombytes": "2.0.6",
+        "safe-buffer": "5.1.2",
+        "typeforce": "1.12.0",
+        "varuint-bitcoin": "1.1.0",
+        "wif": "2.0.6"
       }
     },
     "bl": {
@@ -321,8 +321,8 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-2.0.1.tgz",
       "integrity": "sha512-FrMgLukB9jujvJ92p5TA0hcKIHtInVXXhxD7qgAuV7k0cbPt9USZmOYnhDXH6IsnGeIUglX42TSBV7Gn4q5sbQ==",
       "requires": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
+        "readable-stream": "2.3.6",
+        "safe-buffer": "5.1.2"
       }
     },
     "blakejs": {
@@ -345,7 +345,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
       "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
       "requires": {
-        "hoek": "5.x.x"
+        "hoek": "5.0.3"
       }
     },
     "borc": {
@@ -353,10 +353,10 @@
       "resolved": "https://registry.npmjs.org/borc/-/borc-2.0.3.tgz",
       "integrity": "sha512-2mfipKUXn7yLgwn8D5jZkJqd2ZyzqmYZQX/9d4On33oGNDLwxj5qQMst+nkKyEdaujQRFfrZCId+k8wehQVANg==",
       "requires": {
-        "bignumber.js": "^6.0.0",
-        "commander": "^2.15.0",
-        "ieee754": "^1.1.8",
-        "json-text-sequence": "^0.1"
+        "bignumber.js": "6.0.0",
+        "commander": "2.16.0",
+        "ieee754": "1.1.12",
+        "json-text-sequence": "0.1.1"
       }
     },
     "boxen": {
@@ -364,13 +364,13 @@
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
       "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
       "requires": {
-        "ansi-align": "^2.0.0",
-        "camelcase": "^4.0.0",
-        "chalk": "^2.0.1",
-        "cli-boxes": "^1.0.0",
-        "string-width": "^2.0.0",
-        "term-size": "^1.2.0",
-        "widest-line": "^2.0.0"
+        "ansi-align": "2.0.0",
+        "camelcase": "4.1.0",
+        "chalk": "2.4.1",
+        "cli-boxes": "1.0.0",
+        "string-width": "2.1.1",
+        "term-size": "1.2.0",
+        "widest-line": "2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -388,8 +388,8 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -397,7 +397,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -407,7 +407,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -427,12 +427,12 @@
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "requires": {
-        "buffer-xor": "^1.0.3",
-        "cipher-base": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.3",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "buffer-xor": "1.0.3",
+        "cipher-base": "1.0.4",
+        "create-hash": "1.2.0",
+        "evp_bytestokey": "1.0.3",
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "bs58": {
@@ -440,7 +440,7 @@
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
       "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
       "requires": {
-        "base-x": "^3.0.2"
+        "base-x": "3.0.4"
       }
     },
     "bs58check": {
@@ -448,8 +448,8 @@
       "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.1.tgz",
       "integrity": "sha512-okRQiWc5FJuA2VOwQ1hB7Sf0MyEFg/EwRN12h4b8HrJoGkZ3xq1CGjkaAfYloLcZyqixQnO5mhPpN6IcHSplVg==",
       "requires": {
-        "bs58": "^4.0.0",
-        "create-hash": "^1.1.0"
+        "bs58": "4.0.1",
+        "create-hash": "1.2.0"
       }
     },
     "buffer-alloc": {
@@ -457,8 +457,8 @@
       "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
       "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
       "requires": {
-        "buffer-alloc-unsafe": "^1.1.0",
-        "buffer-fill": "^1.0.0"
+        "buffer-alloc-unsafe": "1.1.0",
+        "buffer-fill": "1.0.0"
       }
     },
     "buffer-alloc-unsafe": {
@@ -491,7 +491,7 @@
       "resolved": "https://registry.npmjs.org/buffer-split/-/buffer-split-1.0.0.tgz",
       "integrity": "sha1-RCfb/1NzG2HXpxq6R/UDOWYTeEo=",
       "requires": {
-        "buffer-indexof": "~0.0.0"
+        "buffer-indexof": "0.0.2"
       }
     },
     "buffer-xor": {
@@ -524,8 +524,8 @@
       "resolved": "https://registry.npmjs.org/call/-/call-4.0.2.tgz",
       "integrity": "sha1-33b19R7o3Ui4VqyEAPfmnm1zmcQ=",
       "requires": {
-        "boom": "5.x.x",
-        "hoek": "4.x.x"
+        "boom": "5.2.0",
+        "hoek": "4.2.1"
       },
       "dependencies": {
         "boom": {
@@ -533,7 +533,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "4.2.1"
           }
         },
         "hoek": {
@@ -563,9 +563,9 @@
       "resolved": "https://registry.npmjs.org/catbox/-/catbox-7.1.5.tgz",
       "integrity": "sha512-4fui5lELzqZ+9cnaAP/BcqXTH6LvWLBRtFhJ0I4FfgfXiSaZcf6k9m9dqOyChiTxNYtvLk7ZMYSf7ahMq3bf5A==",
       "requires": {
-        "boom": "5.x.x",
-        "hoek": "4.x.x",
-        "joi": "10.x.x"
+        "boom": "5.2.0",
+        "hoek": "4.2.1",
+        "joi": "10.6.0"
       },
       "dependencies": {
         "boom": {
@@ -573,7 +573,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "4.2.1"
           }
         },
         "hoek": {
@@ -586,10 +586,10 @@
           "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
           "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
           "requires": {
-            "hoek": "4.x.x",
-            "isemail": "2.x.x",
-            "items": "2.x.x",
-            "topo": "2.x.x"
+            "hoek": "4.2.1",
+            "isemail": "2.2.1",
+            "items": "2.1.1",
+            "topo": "2.0.2"
           }
         }
       }
@@ -599,7 +599,7 @@
       "resolved": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-2.0.4.tgz",
       "integrity": "sha1-Qz4lWQLK9UIz0ShkKcj03xToItU=",
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "4.2.1"
       },
       "dependencies": {
         "hoek": {
@@ -614,9 +614,9 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.4.0"
       }
     },
     "chownr": {
@@ -639,9 +639,9 @@
       "resolved": "https://registry.npmjs.org/cids/-/cids-0.5.3.tgz",
       "integrity": "sha512-ujWbNP8SeLKg5KmGrxYZM4c+ttd+wwvegrdtgmbi2KNFUbQN4pqsGZaGQE3rhjayXTbKFq36bYDbKhsnD0eMsg==",
       "requires": {
-        "multibase": "~0.4.0",
-        "multicodec": "~0.2.6",
-        "multihashes": "~0.4.13"
+        "multibase": "0.4.0",
+        "multicodec": "0.2.7",
+        "multihashes": "0.4.13"
       }
     },
     "cipher-base": {
@@ -649,8 +649,8 @@
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "class-is": {
@@ -668,9 +668,9 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
       "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
       "requires": {
-        "string-width": "^2.1.1",
-        "strip-ansi": "^4.0.0",
-        "wrap-ansi": "^2.0.0"
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "wrap-ansi": "2.1.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -688,8 +688,8 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -697,7 +697,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -750,10 +750,10 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "buffer-from": "1.1.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "typedarray": "0.0.6"
       }
     },
     "configstore": {
@@ -761,12 +761,12 @@
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
       "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
       "requires": {
-        "dot-prop": "^4.1.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^1.0.0",
-        "unique-string": "^1.0.0",
-        "write-file-atomic": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
+        "dot-prop": "4.2.0",
+        "graceful-fs": "4.1.11",
+        "make-dir": "1.3.0",
+        "unique-string": "1.0.0",
+        "write-file-atomic": "2.3.0",
+        "xdg-basedir": "3.0.0"
       }
     },
     "console-control-strings": {
@@ -779,7 +779,7 @@
       "resolved": "https://registry.npmjs.org/content/-/content-3.0.7.tgz",
       "integrity": "sha512-LXtnSnvE+Z1Cjpa3P9gh9kb396qV4MqpfwKy777BOSF8n6nw2vAi03tHNl0/XRqZUyzVzY/+nMXOZVnEapWzdg==",
       "requires": {
-        "boom": "5.x.x"
+        "boom": "5.2.0"
       },
       "dependencies": {
         "boom": {
@@ -787,7 +787,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "4.2.1"
           }
         },
         "hoek": {
@@ -817,7 +817,7 @@
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "requires": {
-        "capture-stack-trace": "^1.0.0"
+        "capture-stack-trace": "1.0.0"
       }
     },
     "create-hash": {
@@ -825,11 +825,11 @@
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "requires": {
-        "cipher-base": "^1.0.1",
-        "inherits": "^2.0.1",
-        "md5.js": "^1.3.4",
-        "ripemd160": "^2.0.1",
-        "sha.js": "^2.4.0"
+        "cipher-base": "1.0.4",
+        "inherits": "2.0.3",
+        "md5.js": "1.3.4",
+        "ripemd160": "2.0.2",
+        "sha.js": "2.4.11"
       }
     },
     "create-hmac": {
@@ -837,12 +837,12 @@
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "requires": {
-        "cipher-base": "^1.0.3",
-        "create-hash": "^1.1.0",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "cipher-base": "1.0.4",
+        "create-hash": "1.2.0",
+        "inherits": "2.0.3",
+        "ripemd160": "2.0.2",
+        "safe-buffer": "5.1.2",
+        "sha.js": "2.4.11"
       }
     },
     "cross-spawn": {
@@ -850,9 +850,9 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "requires": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "lru-cache": "4.1.3",
+        "shebang-command": "1.2.0",
+        "which": "1.3.1"
       }
     },
     "cryptiles": {
@@ -860,7 +860,7 @@
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "requires": {
-        "boom": "5.x.x"
+        "boom": "5.2.0"
       },
       "dependencies": {
         "boom": {
@@ -868,7 +868,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "4.2.1"
           }
         },
         "hoek": {
@@ -893,11 +893,11 @@
       "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-0.4.0.tgz",
       "integrity": "sha512-BQC3f2jSUgVL1DUjt/ZJr9yWzNYyx3ApNh4NhMYFZBap0c+iTKJqyHRlO4bRT+CZG0mqqOUTNXU3qYvTJlN6OA==",
       "requires": {
-        "async": "^2.5.0",
-        "interface-datastore": "~0.4.0",
-        "left-pad": "^1.1.3",
-        "pull-many": "^1.0.8",
-        "pull-stream": "^3.6.1"
+        "async": "2.6.1",
+        "interface-datastore": "0.4.2",
+        "left-pad": "1.3.0",
+        "pull-many": "1.0.8",
+        "pull-stream": "3.6.8"
       }
     },
     "datastore-fs": {
@@ -905,14 +905,14 @@
       "resolved": "https://registry.npmjs.org/datastore-fs/-/datastore-fs-0.5.0.tgz",
       "integrity": "sha512-l2WF+/TFzzCY3L0b4GYYa196X25PqR2jZnLvqXtz2WODkTXZTcZJ+s4+KAnUAc6TMxWejN8NkEnkcPL05lKSSA==",
       "requires": {
-        "async": "^2.6.1",
-        "datastore-core": "~0.4.0",
-        "glob": "^7.1.2",
-        "graceful-fs": "^4.1.11",
-        "interface-datastore": "^0.4.2",
-        "mkdirp": "~0.5.1",
-        "pull-stream": "^3.6.8",
-        "write-file-atomic": "^2.3.0"
+        "async": "2.6.1",
+        "datastore-core": "0.4.0",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "interface-datastore": "0.4.2",
+        "mkdirp": "0.5.1",
+        "pull-stream": "3.6.8",
+        "write-file-atomic": "2.3.0"
       }
     },
     "datastore-level": {
@@ -920,13 +920,12 @@
       "resolved": "https://registry.npmjs.org/datastore-level/-/datastore-level-0.8.0.tgz",
       "integrity": "sha512-RSklSUhf4CBNXm8akR+Q7LvDE4J6NA8XfZ3h5pGPempdXcExFui5CoyHJscOlu0culvZzuJLU4k5PxcLPGzuMw==",
       "requires": {
-        "datastore-core": "~0.4.0",
-        "encoding-down": "^5.0.2",
-        "interface-datastore": "~0.4.1",
-        "level-js": "github:timkuijsten/level.js#18e03adab34c49523be7d3d58fafb0c632f61303",
-        "leveldown": "^3.0.2",
-        "levelup": "^2.0.2",
-        "pull-stream": "^3.6.1"
+        "datastore-core": "0.4.0",
+        "encoding-down": "5.0.4",
+        "interface-datastore": "0.4.2",
+        "leveldown": "3.0.2",
+        "levelup": "2.0.2",
+        "pull-stream": "3.6.8"
       }
     },
     "debug": {
@@ -950,7 +949,7 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "requires": {
-        "mimic-response": "^1.0.0"
+        "mimic-response": "1.0.1"
       }
     },
     "deep-extend": {
@@ -968,7 +967,7 @@
       "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-3.0.0.tgz",
       "integrity": "sha512-ajbXqRPMXRlcdyt0TuWqknOJkp1JgQjGB7xOl2V+ebol7/U11E9h3/nCZAtN1M7djmAJEIhypCUc1tIWxdQAuQ==",
       "requires": {
-        "abstract-leveldown": "~4.0.0"
+        "abstract-leveldown": "4.0.3"
       },
       "dependencies": {
         "abstract-leveldown": {
@@ -976,7 +975,7 @@
           "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-4.0.3.tgz",
           "integrity": "sha512-qsIHFQy0u17JqSY+3ZUT+ykqxYY17yOfvAsLkFkw8kSQqi05d1jyj0bCuSX6sjYlXuY9cKpgUt5EudQdP4aXyA==",
           "requires": {
-            "xtend": "~4.0.0"
+            "xtend": "4.0.1"
           }
         }
       }
@@ -1006,7 +1005,7 @@
       "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
       "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
       "requires": {
-        "readable-stream": "1.1.x",
+        "readable-stream": "1.1.14",
         "streamsearch": "0.1.2"
       },
       "dependencies": {
@@ -1020,10 +1019,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -1049,8 +1048,8 @@
       "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-4.2.0.tgz",
       "integrity": "sha512-bn1AKpfkFbm0MIioOMHZ5qJzl2uypdBwI4nYNsqvhjsegBhcKJUlCrMPWLx6JEezRjxZmxhtIz/FkBEur2l8Cw==",
       "requires": {
-        "ip": "^1.1.5",
-        "safe-buffer": "^5.1.1"
+        "ip": "1.1.5",
+        "safe-buffer": "5.1.2"
       }
     },
     "dot-prop": {
@@ -1058,7 +1057,7 @@
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
       "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
       "requires": {
-        "is-obj": "^1.0.0"
+        "is-obj": "1.0.1"
       }
     },
     "drbg.js": {
@@ -1066,9 +1065,9 @@
       "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
       "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
       "requires": {
-        "browserify-aes": "^1.0.6",
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4"
+        "browserify-aes": "1.2.0",
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7"
       }
     },
     "duplexer3": {
@@ -1081,10 +1080,10 @@
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
       "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
       "requires": {
-        "end-of-stream": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0",
-        "stream-shift": "^1.0.0"
+        "end-of-stream": "1.4.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "stream-shift": "1.0.0"
       }
     },
     "ecurve": {
@@ -1092,8 +1091,8 @@
       "resolved": "https://registry.npmjs.org/ecurve/-/ecurve-1.0.6.tgz",
       "integrity": "sha512-/BzEjNfiSuB7jIWKcS/z8FK9jNjmEWvUV2YZ4RLSmcDtP7Lq0m6FvDuSnJpBlDpGRpfRQeTLGLBI8H+kEv0r+w==",
       "requires": {
-        "bigi": "^1.1.0",
-        "safe-buffer": "^5.0.1"
+        "bigi": "1.4.2",
+        "safe-buffer": "5.1.2"
       }
     },
     "elliptic": {
@@ -1101,13 +1100,13 @@
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0",
+        "hash.js": "1.1.5",
+        "hmac-drbg": "1.0.1",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1",
+        "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "encoding-down": {
@@ -1115,11 +1114,11 @@
       "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-5.0.4.tgz",
       "integrity": "sha512-8CIZLDcSKxgzT+zX8ZVfgNbu8Md2wq/iqa1Y7zyVR18QBEAc0Nmzuvj/N5ykSKpfGzjM8qxbaFntLPwnVoUhZw==",
       "requires": {
-        "abstract-leveldown": "^5.0.0",
-        "inherits": "^2.0.3",
-        "level-codec": "^9.0.0",
-        "level-errors": "^2.0.0",
-        "xtend": "^4.0.1"
+        "abstract-leveldown": "5.0.0",
+        "inherits": "2.0.3",
+        "level-codec": "9.0.0",
+        "level-errors": "2.0.0",
+        "xtend": "4.0.1"
       }
     },
     "end-of-stream": {
@@ -1127,7 +1126,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
-        "once": "^1.4.0"
+        "once": "1.4.0"
       }
     },
     "engine.io": {
@@ -1135,12 +1134,12 @@
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.0.tgz",
       "integrity": "sha512-mRbgmAtQ4GAlKwuPnnAvXXwdPhEx+jkc0OBCLrXuD/CRvwNK3AxRSnqK4FSqmAMRRHryVJP8TopOvmEaA64fKw==",
       "requires": {
-        "accepts": "~1.3.4",
+        "accepts": "1.3.5",
         "base64id": "1.0.0",
         "cookie": "0.3.1",
-        "debug": "~3.1.0",
-        "engine.io-parser": "~2.1.0",
-        "ws": "~3.3.1"
+        "debug": "3.1.0",
+        "engine.io-parser": "2.1.2",
+        "ws": "3.3.3"
       },
       "dependencies": {
         "ultron": {
@@ -1153,9 +1152,9 @@
           "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
           "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
           "requires": {
-            "async-limiter": "~1.0.0",
-            "safe-buffer": "~5.1.0",
-            "ultron": "~1.1.0"
+            "async-limiter": "1.0.0",
+            "safe-buffer": "5.1.2",
+            "ultron": "1.1.1"
           }
         }
       }
@@ -1167,14 +1166,14 @@
       "requires": {
         "component-emitter": "1.2.1",
         "component-inherit": "0.0.3",
-        "debug": "~3.1.0",
-        "engine.io-parser": "~2.1.1",
+        "debug": "3.1.0",
+        "engine.io-parser": "2.1.2",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "ws": "~3.3.1",
-        "xmlhttprequest-ssl": "~1.5.4",
+        "ws": "3.3.3",
+        "xmlhttprequest-ssl": "1.5.5",
         "yeast": "0.1.2"
       },
       "dependencies": {
@@ -1188,9 +1187,9 @@
           "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
           "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
           "requires": {
-            "async-limiter": "~1.0.0",
-            "safe-buffer": "~5.1.0",
-            "ultron": "~1.1.0"
+            "async-limiter": "1.0.0",
+            "safe-buffer": "5.1.2",
+            "ultron": "1.1.1"
           }
         }
       }
@@ -1201,10 +1200,10 @@
       "integrity": "sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
       "requires": {
         "after": "0.8.2",
-        "arraybuffer.slice": "~0.0.7",
+        "arraybuffer.slice": "0.0.7",
         "base64-arraybuffer": "0.1.5",
         "blob": "0.0.4",
-        "has-binary2": "~1.0.2"
+        "has-binary2": "1.0.3"
       }
     },
     "epimetheus": {
@@ -1212,7 +1211,7 @@
       "resolved": "https://registry.npmjs.org/epimetheus/-/epimetheus-1.0.55.tgz",
       "integrity": "sha1-j0dAiy1oCxIm/9IF1QH499XikgY=",
       "requires": {
-        "prom-client": "^10.0.0"
+        "prom-client": "10.2.3"
       },
       "dependencies": {
         "prom-client": {
@@ -1220,7 +1219,7 @@
           "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-10.2.3.tgz",
           "integrity": "sha512-Xboq5+TdUwuQtSSDRZRNnb5NprINlgQN999VqUjZxnLKydUNLeIPx6Eiahg6oJua3XBg2TGnh5Cth1s4I6+r7g==",
           "requires": {
-            "tdigest": "^0.1.1"
+            "tdigest": "0.1.1"
           }
         }
       }
@@ -1230,7 +1229,7 @@
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "requires": {
-        "prr": "~1.0.1"
+        "prr": "1.0.1"
       }
     },
     "error-ex": {
@@ -1238,7 +1237,7 @@
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "escape-string-regexp": {
@@ -1256,9 +1255,9 @@
       "resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-2.0.5.tgz",
       "integrity": "sha512-bgDojnXGjhMwo6eXQC0bY6UK2liSFUSMwwylOmQvZbSl/D7NXQ3+vrGO46ZeOgjGfxXmgIeVNDIiHw7fNZM4VA==",
       "requires": {
-        "ethereumjs-util": "^5.0.0",
-        "rlp": "^2.0.0",
-        "safe-buffer": "^5.1.1"
+        "ethereumjs-util": "5.2.0",
+        "rlp": "2.1.0",
+        "safe-buffer": "5.1.2"
       }
     },
     "ethereumjs-block": {
@@ -1266,11 +1265,11 @@
       "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
       "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
       "requires": {
-        "async": "^2.0.1",
+        "async": "2.6.1",
         "ethereum-common": "0.2.0",
-        "ethereumjs-tx": "^1.2.2",
-        "ethereumjs-util": "^5.0.0",
-        "merkle-patricia-tree": "^2.1.2"
+        "ethereumjs-tx": "1.3.6",
+        "ethereumjs-util": "5.2.0",
+        "merkle-patricia-tree": "2.3.1"
       }
     },
     "ethereumjs-tx": {
@@ -1278,8 +1277,8 @@
       "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.6.tgz",
       "integrity": "sha512-wzsEs0mCSLqdDjqSDg6AWh1hyL8H3R/pyZxehkcCXq5MJEFXWz+eJ2jSv+3yEaLy6tXrNP7dmqS3Kyb3zAONkg==",
       "requires": {
-        "ethereum-common": "^0.0.18",
-        "ethereumjs-util": "^5.0.0"
+        "ethereum-common": "0.0.18",
+        "ethereumjs-util": "5.2.0"
       },
       "dependencies": {
         "ethereum-common": {
@@ -1294,13 +1293,13 @@
       "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
       "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
       "requires": {
-        "bn.js": "^4.11.0",
-        "create-hash": "^1.1.2",
-        "ethjs-util": "^0.1.3",
-        "keccak": "^1.0.2",
-        "rlp": "^2.0.0",
-        "safe-buffer": "^5.1.1",
-        "secp256k1": "^3.0.1"
+        "bn.js": "4.11.8",
+        "create-hash": "1.2.0",
+        "ethjs-util": "0.1.6",
+        "keccak": "1.4.0",
+        "rlp": "2.1.0",
+        "safe-buffer": "5.1.2",
+        "secp256k1": "3.5.0"
       }
     },
     "ethjs-util": {
@@ -1317,8 +1316,8 @@
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "requires": {
-        "md5.js": "^1.3.4",
-        "safe-buffer": "^5.1.1"
+        "md5.js": "1.3.4",
+        "safe-buffer": "5.1.2"
       }
     },
     "execa": {
@@ -1326,13 +1325,13 @@
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
       }
     },
     "expand-template": {
@@ -1350,14 +1349,14 @@
       "resolved": "https://registry.npmjs.org/file-api/-/file-api-0.10.4.tgz",
       "integrity": "sha1-LxASJttyfMAXKg3WiPL2iD1SiD0=",
       "requires": {
-        "File": ">= 0.10.0",
-        "FileList": ">= 0.10.0",
-        "bufferjs": "> 0.2.0",
-        "file-error": ">= 0.10.0",
-        "filereader": ">= 0.10.3",
-        "formdata": ">= 0.10.0",
-        "mime": ">= 1.2.11",
-        "remedial": ">= 1.0.7"
+        "File": "0.10.2",
+        "FileList": "0.10.2",
+        "bufferjs": "3.0.1",
+        "file-error": "0.10.2",
+        "filereader": "0.10.3",
+        "formdata": "0.10.4",
+        "mime": "2.3.1",
+        "remedial": "1.0.8"
       }
     },
     "file-error": {
@@ -1380,8 +1379,8 @@
       "resolved": "https://registry.npmjs.org/filereader-stream/-/filereader-stream-2.0.0.tgz",
       "integrity": "sha1-sw1aW/bRTGONfrVeGTq7mG+ASKE=",
       "requires": {
-        "from2": "^2.1.0",
-        "typedarray-to-buffer": "^3.0.4"
+        "from2": "2.3.0",
+        "typedarray-to-buffer": "3.1.5"
       }
     },
     "filesize": {
@@ -1394,9 +1393,9 @@
       "resolved": "https://registry.npmjs.org/find-process/-/find-process-1.1.1.tgz",
       "integrity": "sha1-V/sa28f0MEeG23IKSf69cIoxYtQ=",
       "requires": {
-        "chalk": "^2.0.1",
-        "commander": "^2.11.0",
-        "debug": "^2.6.8"
+        "chalk": "2.4.1",
+        "commander": "2.16.0",
+        "debug": "2.6.9"
       },
       "dependencies": {
         "debug": {
@@ -1414,7 +1413,7 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "requires": {
-        "locate-path": "^3.0.0"
+        "locate-path": "3.0.0"
       }
     },
     "flatmap": {
@@ -1437,12 +1436,12 @@
       "resolved": "https://registry.npmjs.org/formdata/-/formdata-0.10.4.tgz",
       "integrity": "sha1-liH9wMw2H0oBEd5dJbNfanjcVaA=",
       "requires": {
-        "File": "^0.10.2",
-        "FileList": "^0.10.2",
-        "bufferjs": "^2.0.0",
-        "filereader": "^0.10.3",
-        "foreachasync": "^3.0.0",
-        "remedial": "^1.0.7"
+        "File": "0.10.2",
+        "FileList": "0.10.2",
+        "bufferjs": "2.0.0",
+        "filereader": "0.10.3",
+        "foreachasync": "3.0.0",
+        "remedial": "1.0.8"
       },
       "dependencies": {
         "bufferjs": {
@@ -1457,22 +1456,14 @@
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
       }
     },
     "fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
-    },
-    "fs-ext": {
-      "version": "github:baudehlo/node-fs-ext#7c9824f3dc330e795aa13359d96252860bd3a684",
-      "from": "github:baudehlo/node-fs-ext#master",
-      "optional": true,
-      "requires": {
-        "nan": "^2.10.0"
-      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -1484,7 +1475,7 @@
       "resolved": "https://registry.npmjs.org/fsm/-/fsm-1.0.2.tgz",
       "integrity": "sha1-4uubKXR+gGu7kPjVRT4vnXvSN4M=",
       "requires": {
-        "split": "~0.3.0"
+        "split": "0.3.3"
       }
     },
     "fsm-event": {
@@ -1492,7 +1483,7 @@
       "resolved": "https://registry.npmjs.org/fsm-event/-/fsm-event-2.1.0.tgz",
       "integrity": "sha1-04VxbtOPnJL+qyumAeKqxsC6WpI=",
       "requires": {
-        "fsm": "^1.0.2"
+        "fsm": "1.0.2"
       }
     },
     "functional-red-black-tree": {
@@ -1510,14 +1501,14 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "requires": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
+        "aproba": "1.2.0",
+        "console-control-strings": "1.1.0",
+        "has-unicode": "2.0.1",
+        "object-assign": "4.1.1",
+        "signal-exit": "3.0.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wide-align": "1.1.3"
       },
       "dependencies": {
         "object-assign": {
@@ -1533,8 +1524,8 @@
       "integrity": "sha512-Fv+EbJ1zhI+HWJ1GknC4Tn90KcovQIGQgYbJp85GY7pluRj6n0feIIwdKgeSY3lG5fno2XdyUTZKtIWLdHF22Q==",
       "optional": true,
       "requires": {
-        "nan": "^2.10.0",
-        "node-pre-gyp": "^0.10.0"
+        "nan": "2.10.0",
+        "node-pre-gyp": "0.10.0"
       },
       "dependencies": {
         "abbrev": {
@@ -1556,8 +1547,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
           }
         },
         "balanced-match": {
@@ -1568,7 +1559,7 @@
           "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -1622,7 +1613,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.3.3"
           }
         },
         "fs.realpath": {
@@ -1635,14 +1626,14 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.3"
           }
         },
         "glob": {
@@ -1650,12 +1641,12 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "has-unicode": {
@@ -1668,7 +1659,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
+            "safer-buffer": "2.1.2"
           }
         },
         "ignore-walk": {
@@ -1676,7 +1667,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "minimatch": "^3.0.4"
+            "minimatch": "3.0.4"
           }
         },
         "inflight": {
@@ -1684,8 +1675,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -1701,7 +1692,7 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "isarray": {
@@ -1713,7 +1704,7 @@
           "version": "3.0.4",
           "bundled": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
@@ -1724,8 +1715,8 @@
           "version": "2.3.3",
           "bundled": true,
           "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.2"
           }
         },
         "minizlib": {
@@ -1733,7 +1724,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.3.3"
           }
         },
         "mkdirp": {
@@ -1753,9 +1744,9 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "debug": "^2.1.2",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.23",
+            "sax": "1.2.4"
           },
           "dependencies": {
             "sax": {
@@ -1770,16 +1761,16 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.1",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.1.10",
+            "npmlog": "4.1.2",
+            "rc": "1.2.8",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "4.4.4"
           },
           "dependencies": {
             "tar": {
@@ -1787,13 +1778,13 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "chownr": "^1.0.1",
-                "fs-minipass": "^1.2.5",
-                "minipass": "^2.3.3",
-                "minizlib": "^1.1.0",
-                "mkdirp": "^0.5.0",
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.2"
+                "chownr": "1.0.1",
+                "fs-minipass": "1.2.5",
+                "minipass": "2.3.3",
+                "minizlib": "1.1.0",
+                "mkdirp": "0.5.1",
+                "safe-buffer": "5.1.2",
+                "yallist": "3.0.2"
               }
             }
           }
@@ -1803,8 +1794,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
           }
         },
         "npm-bundled": {
@@ -1817,8 +1808,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
           }
         },
         "npmlog": {
@@ -1826,10 +1817,10 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.5",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "number-is-nan": {
@@ -1845,7 +1836,7 @@
           "version": "1.4.0",
           "bundled": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
@@ -1863,8 +1854,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "path-is-absolute": {
@@ -1882,10 +1873,10 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "deep-extend": "^0.6.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.6.0",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -1900,13 +1891,13 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "rimraf": {
@@ -1914,7 +1905,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "safe-buffer": {
@@ -1945,9 +1936,9 @@
           "version": "1.0.2",
           "bundled": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "string_decoder": {
@@ -1955,14 +1946,14 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
@@ -1980,7 +1971,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2 || 2"
+            "string-width": "1.0.2"
           }
         },
         "wrappy": {
@@ -2008,7 +1999,7 @@
       "resolved": "https://registry.npmjs.org/get-folder-size/-/get-folder-size-2.0.0.tgz",
       "integrity": "sha512-5h4efQY/sHvf9ZuwOan1HgNaRyApKnJjZ1ZdTOPkpTjIHZNqeMTabBU/LLN6lU9jncBwxJKFcG9cuqiGhu47uQ==",
       "requires": {
-        "gar": "^1.0.2",
+        "gar": "1.0.3",
         "tiny-each-async": "2.0.3"
       }
     },
@@ -2027,12 +2018,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "global-dirs": {
@@ -2040,7 +2031,7 @@
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "requires": {
-        "ini": "^1.3.4"
+        "ini": "1.3.5"
       }
     },
     "got": {
@@ -2048,17 +2039,17 @@
       "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "requires": {
-        "create-error-class": "^3.0.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^3.0.0",
-        "is-redirect": "^1.0.0",
-        "is-retry-allowed": "^1.0.0",
-        "is-stream": "^1.0.0",
-        "lowercase-keys": "^1.0.0",
-        "safe-buffer": "^5.0.1",
-        "timed-out": "^4.0.0",
-        "unzip-response": "^2.0.1",
-        "url-parse-lax": "^1.0.0"
+        "create-error-class": "3.0.2",
+        "duplexer3": "0.1.4",
+        "get-stream": "3.0.0",
+        "is-redirect": "1.0.0",
+        "is-retry-allowed": "1.1.0",
+        "is-stream": "1.1.0",
+        "lowercase-keys": "1.0.1",
+        "safe-buffer": "5.1.2",
+        "timed-out": "4.0.1",
+        "unzip-response": "2.0.1",
+        "url-parse-lax": "1.0.0"
       }
     },
     "graceful-fs": {
@@ -2077,24 +2068,24 @@
       "resolved": "https://registry.npmjs.org/hapi/-/hapi-16.6.3.tgz",
       "integrity": "sha512-Fe1EtSlRWdez9c1sLDrHZYxpsp3IddwtUWp7y65TCBW5CMcBP98X4WnoBJZTGsDZnk/FDkRyEMhUVsC9qysDPg==",
       "requires": {
-        "accept": "^2.1.4",
-        "ammo": "^2.0.4",
-        "boom": "^5.2.0",
-        "call": "^4.0.2",
-        "catbox": "^7.1.5",
-        "catbox-memory": "^2.0.4",
-        "cryptiles": "^3.1.2",
-        "heavy": "^4.0.4",
-        "hoek": "^4.2.0",
-        "iron": "^4.0.5",
-        "items": "^2.1.1",
-        "joi": "^11.1.0",
-        "mimos": "^3.0.3",
-        "podium": "^1.3.0",
-        "shot": "^3.4.2",
-        "statehood": "^5.0.3",
-        "subtext": "^5.0.0",
-        "topo": "^2.0.2"
+        "accept": "2.1.4",
+        "ammo": "2.0.4",
+        "boom": "5.2.0",
+        "call": "4.0.2",
+        "catbox": "7.1.5",
+        "catbox-memory": "2.0.4",
+        "cryptiles": "3.1.2",
+        "heavy": "4.0.4",
+        "hoek": "4.2.1",
+        "iron": "4.0.5",
+        "items": "2.1.1",
+        "joi": "11.4.0",
+        "mimos": "3.0.3",
+        "podium": "1.3.0",
+        "shot": "3.4.2",
+        "statehood": "5.0.3",
+        "subtext": "5.0.0",
+        "topo": "2.0.2"
       },
       "dependencies": {
         "boom": {
@@ -2102,7 +2093,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "4.2.1"
           }
         },
         "hoek": {
@@ -2115,7 +2106,7 @@
           "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.3.tgz",
           "integrity": "sha512-5xbsG5wYADIcB+mfLsd+nst1V/D+I7EU7LEZPo2GOIMu4JzfcRs5yQoypP4avA7QtUqgxYLKBYNv4IdzBmbhdw==",
           "requires": {
-            "punycode": "2.x.x"
+            "punycode": "2.1.1"
           }
         },
         "joi": {
@@ -2123,9 +2114,9 @@
           "resolved": "https://registry.npmjs.org/joi/-/joi-11.4.0.tgz",
           "integrity": "sha512-O7Uw+w/zEWgbL6OcHbyACKSj0PkQeUgmehdoXVSxt92QFCq4+1390Rwh5moI2K/OgC7D8RHRZqHZxT2husMJHA==",
           "requires": {
-            "hoek": "4.x.x",
-            "isemail": "3.x.x",
-            "topo": "2.x.x"
+            "hoek": "4.2.1",
+            "isemail": "3.1.3",
+            "topo": "2.0.2"
           }
         }
       }
@@ -2170,8 +2161,8 @@
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "hash.js": {
@@ -2179,8 +2170,8 @@
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.5.tgz",
       "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
       "requires": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1"
       }
     },
     "hashlru": {
@@ -2204,9 +2195,9 @@
       "resolved": "https://registry.npmjs.org/heavy/-/heavy-4.0.4.tgz",
       "integrity": "sha1-NskTNsAMz+hSyqTRUwhjNc0vAOk=",
       "requires": {
-        "boom": "5.x.x",
-        "hoek": "4.x.x",
-        "joi": "10.x.x"
+        "boom": "5.2.0",
+        "hoek": "4.2.1",
+        "joi": "10.6.0"
       },
       "dependencies": {
         "boom": {
@@ -2214,7 +2205,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "4.2.1"
           }
         },
         "hoek": {
@@ -2227,10 +2218,10 @@
           "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
           "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
           "requires": {
-            "hoek": "4.x.x",
-            "isemail": "2.x.x",
-            "items": "2.x.x",
-            "topo": "2.x.x"
+            "hoek": "4.2.1",
+            "isemail": "2.2.1",
+            "items": "2.1.1",
+            "topo": "2.0.2"
           }
         }
       }
@@ -2240,9 +2231,9 @@
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "requires": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
+        "hash.js": "1.1.5",
+        "minimalistic-assert": "1.0.1",
+        "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "hoek": {
@@ -2260,15 +2251,7 @@
       "resolved": "https://registry.npmjs.org/human-to-milliseconds/-/human-to-milliseconds-1.0.0.tgz",
       "integrity": "sha512-Rp1uvdGYHZ8v6GCl3N6QW48MlABqvLCzKbeNPPddbFdDEC7G1G+8oq0hmCiem4PSJIDwLvAxkPi3FF5BDoeKew==",
       "requires": {
-        "promisify-es6": "^1.0.3"
-      }
-    },
-    "idb-readable-stream": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/idb-readable-stream/-/idb-readable-stream-0.0.4.tgz",
-      "integrity": "sha1-MoPaZkW/ayINxhumHfYr7l2uSs8=",
-      "requires": {
-        "xtend": "^4.0.1"
+        "promisify-es6": "1.0.3"
       }
     },
     "idb-wrapper": {
@@ -2306,12 +2289,12 @@
       "resolved": "https://registry.npmjs.org/inert/-/inert-4.2.1.tgz",
       "integrity": "sha512-qmbbZYPSzU/eOUOStPQvSjrU9IR1Q3uDtsEsVwnBQeZG43xu7Nrj6yuUrX3ice/03rv5dj/KiKB+NGCbiqH+aQ==",
       "requires": {
-        "ammo": "2.x.x",
-        "boom": "5.x.x",
-        "hoek": "4.x.x",
-        "items": "2.x.x",
-        "joi": "10.x.x",
-        "lru-cache": "4.1.x"
+        "ammo": "2.0.4",
+        "boom": "5.2.0",
+        "hoek": "4.2.1",
+        "items": "2.1.1",
+        "joi": "10.6.0",
+        "lru-cache": "4.1.3"
       },
       "dependencies": {
         "boom": {
@@ -2319,7 +2302,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "4.2.1"
           }
         },
         "hoek": {
@@ -2332,10 +2315,10 @@
           "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
           "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
           "requires": {
-            "hoek": "4.x.x",
-            "isemail": "2.x.x",
-            "items": "2.x.x",
-            "topo": "2.x.x"
+            "hoek": "4.2.1",
+            "isemail": "2.2.1",
+            "items": "2.1.1",
+            "topo": "2.0.2"
           }
         }
       }
@@ -2345,8 +2328,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -2364,8 +2347,8 @@
       "resolved": "https://registry.npmjs.org/interface-connection/-/interface-connection-0.3.2.tgz",
       "integrity": "sha1-5JSYg/bqeft+3QHuP0/KR6Kf0sQ=",
       "requires": {
-        "pull-defer": "~0.2.2",
-        "timed-tape": "~0.1.1"
+        "pull-defer": "0.2.2",
+        "timed-tape": "0.1.1"
       }
     },
     "interface-datastore": {
@@ -2373,10 +2356,10 @@
       "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-0.4.2.tgz",
       "integrity": "sha512-Vztsb1SXZANtwwGkpDoxOTMELhhuCklkQKbjma6PY4XLwIyrhQ1xEKaG1sOHavMXoghThw8IZEysiCDrofOQKQ==",
       "requires": {
-        "async": "^2.6.0",
-        "pull-defer": "^0.2.2",
-        "pull-stream": "^3.6.1",
-        "uuid": "^3.1.0"
+        "async": "2.6.1",
+        "pull-defer": "0.2.2",
+        "pull-stream": "3.6.8",
+        "uuid": "3.3.2"
       }
     },
     "invert-kv": {
@@ -2395,11 +2378,11 @@
       "integrity": "sha512-7ay355oMN34iXhET1BmCJVsHjOTSItEEIIpOs38qUC23AIhOy+xIPnkrTuEFjeLMrTJ7m8KMXWgWfy/2Vn9sDw==",
       "requires": {
         "jsbn": "1.1.0",
-        "lodash.find": "^4.6.0",
-        "lodash.max": "^4.0.1",
-        "lodash.merge": "^4.6.0",
-        "lodash.padstart": "^4.6.1",
-        "lodash.repeat": "^4.1.0",
+        "lodash.find": "4.6.0",
+        "lodash.max": "4.0.1",
+        "lodash.merge": "4.6.1",
+        "lodash.padstart": "4.6.1",
+        "lodash.repeat": "4.1.0",
         "sprintf-js": "1.1.0"
       }
     },
@@ -2408,95 +2391,95 @@
       "resolved": "https://registry.npmjs.org/ipfs/-/ipfs-0.30.1.tgz",
       "integrity": "sha512-Vks8ADqtuRR9lMDr7hS7qpA2C6TiJDwwsK7m9Bih0nvy+ZWlnvDWajJD9h+zUtkIJZT2PldcT5/6rZhQKd5TcQ==",
       "requires": {
-        "@nodeutils/defaults-deep": "^1.1.0",
-        "async": "^2.6.1",
-        "big.js": "^5.1.2",
-        "binary-querystring": "~0.1.2",
-        "bl": "^2.0.1",
-        "boom": "^7.2.0",
-        "bs58": "^4.0.1",
-        "byteman": "^1.3.5",
-        "cids": "~0.5.3",
-        "debug": "^3.1.0",
-        "file-type": "^8.0.0",
-        "filesize": "^3.6.1",
-        "fnv1a": "^1.0.1",
-        "fsm-event": "^2.1.0",
-        "get-folder-size": "^2.0.0",
-        "glob": "^7.1.2",
-        "hapi": "^16.6.2",
-        "hapi-set-header": "^1.0.2",
-        "hoek": "^5.0.3",
-        "human-to-milliseconds": "^1.0.0",
-        "interface-datastore": "~0.4.2",
-        "ipfs-api": "^22.2.1",
-        "ipfs-bitswap": "~0.20.2",
-        "ipfs-block": "~0.7.1",
-        "ipfs-block-service": "~0.14.0",
-        "ipfs-http-response": "~0.1.2",
-        "ipfs-mfs": "~0.1.0",
-        "ipfs-multipart": "~0.1.0",
-        "ipfs-repo": "~0.22.1",
-        "ipfs-unixfs": "~0.1.15",
-        "ipfs-unixfs-engine": "~0.30.0",
-        "ipld": "~0.17.2",
-        "ipld-dag-cbor": "~0.12.1",
-        "ipld-dag-pb": "~0.14.5",
-        "is-ipfs": "~0.3.2",
-        "is-pull-stream": "~0.0.0",
-        "is-stream": "^1.1.0",
-        "joi": "^13.4.0",
-        "joi-browser": "^13.4.0",
-        "joi-multiaddr": "^2.0.0",
-        "libp2p": "~0.22.0",
-        "libp2p-bootstrap": "~0.9.3",
-        "libp2p-circuit": "~0.2.0",
-        "libp2p-floodsub": "~0.15.0",
-        "libp2p-kad-dht": "~0.10.0",
-        "libp2p-keychain": "~0.3.1",
-        "libp2p-mdns": "~0.12.0",
-        "libp2p-mplex": "~0.8.0",
-        "libp2p-secio": "~0.10.0",
-        "libp2p-tcp": "~0.12.0",
-        "libp2p-webrtc-star": "~0.15.3",
-        "libp2p-websocket-star": "~0.8.1",
-        "libp2p-websockets": "~0.12.0",
-        "lodash": "^4.17.10",
-        "mafmt": "^6.0.0",
-        "mime-types": "^2.1.18",
-        "mkdirp": "~0.5.1",
-        "multiaddr": "^5.0.0",
-        "multibase": "~0.4.0",
-        "multihashes": "~0.4.13",
-        "once": "^1.4.0",
-        "path-exists": "^3.0.0",
-        "peer-book": "~0.8.0",
-        "peer-id": "~0.11.0",
-        "peer-info": "~0.14.1",
-        "progress": "^2.0.0",
-        "prom-client": "^11.1.1",
-        "prometheus-gc-stats": "~0.5.1",
-        "promisify-es6": "^1.0.3",
-        "pull-abortable": "^4.1.1",
-        "pull-defer": "~0.2.2",
-        "pull-file": "^1.1.0",
-        "pull-ndjson": "~0.1.1",
-        "pull-paramap": "^1.2.2",
-        "pull-pushable": "^2.2.0",
-        "pull-sort": "^1.0.1",
-        "pull-stream": "^3.6.8",
-        "pull-stream-to-stream": "^1.3.4",
-        "pull-zip": "^2.0.1",
-        "read-pkg-up": "^4.0.0",
+        "@nodeutils/defaults-deep": "1.1.0",
+        "async": "2.6.1",
+        "big.js": "5.1.2",
+        "binary-querystring": "0.1.2",
+        "bl": "2.0.1",
+        "boom": "7.2.0",
+        "bs58": "4.0.1",
+        "byteman": "1.3.5",
+        "cids": "0.5.3",
+        "debug": "3.1.0",
+        "file-type": "8.1.0",
+        "filesize": "3.6.1",
+        "fnv1a": "1.0.1",
+        "fsm-event": "2.1.0",
+        "get-folder-size": "2.0.0",
+        "glob": "7.1.2",
+        "hapi": "16.6.3",
+        "hapi-set-header": "1.0.2",
+        "hoek": "5.0.3",
+        "human-to-milliseconds": "1.0.0",
+        "interface-datastore": "0.4.2",
+        "ipfs-api": "22.2.4",
+        "ipfs-bitswap": "0.20.3",
+        "ipfs-block": "0.7.1",
+        "ipfs-block-service": "0.14.0",
+        "ipfs-http-response": "0.1.2",
+        "ipfs-mfs": "0.1.0",
+        "ipfs-multipart": "0.1.0",
+        "ipfs-repo": "0.22.1",
+        "ipfs-unixfs": "0.1.15",
+        "ipfs-unixfs-engine": "0.30.0",
+        "ipld": "0.17.3",
+        "ipld-dag-cbor": "0.12.1",
+        "ipld-dag-pb": "0.14.5",
+        "is-ipfs": "0.3.2",
+        "is-pull-stream": "0.0.0",
+        "is-stream": "1.1.0",
+        "joi": "13.4.0",
+        "joi-browser": "13.4.0",
+        "joi-multiaddr": "2.0.0",
+        "libp2p": "0.22.0",
+        "libp2p-bootstrap": "0.9.3",
+        "libp2p-circuit": "0.2.0",
+        "libp2p-floodsub": "0.15.0",
+        "libp2p-kad-dht": "0.10.1",
+        "libp2p-keychain": "0.3.1",
+        "libp2p-mdns": "0.12.0",
+        "libp2p-mplex": "0.8.0",
+        "libp2p-secio": "0.10.0",
+        "libp2p-tcp": "0.12.0",
+        "libp2p-webrtc-star": "0.15.3",
+        "libp2p-websocket-star": "0.8.1",
+        "libp2p-websockets": "0.12.0",
+        "lodash": "4.17.10",
+        "mafmt": "6.0.0",
+        "mime-types": "2.1.19",
+        "mkdirp": "0.5.1",
+        "multiaddr": "5.0.0",
+        "multibase": "0.4.0",
+        "multihashes": "0.4.13",
+        "once": "1.4.0",
+        "path-exists": "3.0.0",
+        "peer-book": "0.8.0",
+        "peer-id": "0.11.0",
+        "peer-info": "0.14.1",
+        "progress": "2.0.0",
+        "prom-client": "11.1.1",
+        "prometheus-gc-stats": "0.5.1",
+        "promisify-es6": "1.0.3",
+        "pull-abortable": "4.1.1",
+        "pull-defer": "0.2.2",
+        "pull-file": "1.1.0",
+        "pull-ndjson": "0.1.1",
+        "pull-paramap": "1.2.2",
+        "pull-pushable": "2.2.0",
+        "pull-sort": "1.0.1",
+        "pull-stream": "3.6.8",
+        "pull-stream-to-stream": "1.3.4",
+        "pull-zip": "2.0.1",
+        "read-pkg-up": "4.0.0",
         "readable-stream": "2.3.6",
-        "stream-to-pull-stream": "^1.7.2",
-        "tar-stream": "^1.6.1",
-        "temp": "~0.8.3",
-        "through2": "^2.0.3",
-        "update-notifier": "^2.5.0",
-        "yargs": "^12.0.1",
-        "yargs-parser": "^10.1.0",
-        "yargs-promise": "^1.1.0"
+        "stream-to-pull-stream": "1.7.2",
+        "tar-stream": "1.6.1",
+        "temp": "0.8.3",
+        "through2": "2.0.3",
+        "update-notifier": "2.5.0",
+        "yargs": "12.0.1",
+        "yargs-parser": "10.1.0",
+        "yargs-promise": "1.1.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -2514,8 +2497,8 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -2523,7 +2506,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         },
         "yargs": {
@@ -2531,18 +2514,18 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.1.tgz",
           "integrity": "sha512-B0vRAp1hRX4jgIOWFtjfNjd9OA9RWYZ6tqGA9/I/IrTMsxmKvtWy+ersM+jzpQqbC3YfLzeABPdeTgcJ9eu1qQ==",
           "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^2.0.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1 || ^4.0.0",
-            "yargs-parser": "^10.1.0"
+            "cliui": "4.1.0",
+            "decamelize": "2.0.0",
+            "find-up": "3.0.0",
+            "get-caller-file": "1.0.3",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "4.0.0",
+            "yargs-parser": "10.1.0"
           }
         }
       }
@@ -2552,42 +2535,42 @@
       "resolved": "https://registry.npmjs.org/ipfs-api/-/ipfs-api-22.2.4.tgz",
       "integrity": "sha512-9RReGD3/O8XQ+K83o9eqge3ULqQGDO9ijg+x3RKskb431Ftqp8Z4MiPRiQxpXKtTkDa1jhStXj2sfENpCQRu9w==",
       "requires": {
-        "async": "^2.6.1",
-        "big.js": "^5.1.2",
-        "bs58": "^4.0.1",
-        "cids": "~0.5.3",
-        "concat-stream": "^1.6.2",
-        "debug": "^3.1.0",
-        "detect-node": "^2.0.3",
+        "async": "2.6.1",
+        "big.js": "5.1.2",
+        "bs58": "4.0.1",
+        "cids": "0.5.3",
+        "concat-stream": "1.6.2",
+        "debug": "3.1.0",
+        "detect-node": "2.0.3",
         "flatmap": "0.0.3",
-        "glob": "^7.1.2",
-        "ipfs-block": "~0.7.1",
-        "ipfs-unixfs": "~0.1.15",
-        "ipld-dag-cbor": "~0.12.1",
-        "ipld-dag-pb": "~0.14.5",
-        "is-ipfs": "~0.3.2",
+        "glob": "7.1.2",
+        "ipfs-block": "0.7.1",
+        "ipfs-unixfs": "0.1.15",
+        "ipld-dag-cbor": "0.12.1",
+        "ipld-dag-pb": "0.14.5",
+        "is-ipfs": "0.3.2",
         "is-pull-stream": "0.0.0",
-        "is-stream": "^1.1.0",
-        "libp2p-crypto": "~0.13.0",
-        "lru-cache": "^4.1.3",
-        "multiaddr": "^5.0.0",
-        "multibase": "~0.4.0",
-        "multihashes": "~0.4.13",
-        "ndjson": "^1.5.0",
-        "once": "^1.4.0",
-        "peer-id": "~0.11.0",
-        "peer-info": "~0.14.1",
-        "promisify-es6": "^1.0.3",
-        "pull-defer": "~0.2.2",
-        "pull-pushable": "^2.2.0",
-        "pull-stream-to-stream": "^1.3.4",
-        "pump": "^3.0.0",
-        "qs": "^6.5.2",
-        "readable-stream": "^2.3.6",
-        "stream-http": "^2.8.3",
-        "stream-to-pull-stream": "^1.7.2",
-        "streamifier": "~0.1.1",
-        "tar-stream": "^1.6.1"
+        "is-stream": "1.1.0",
+        "libp2p-crypto": "0.13.0",
+        "lru-cache": "4.1.3",
+        "multiaddr": "5.0.0",
+        "multibase": "0.4.0",
+        "multihashes": "0.4.13",
+        "ndjson": "1.5.0",
+        "once": "1.4.0",
+        "peer-id": "0.11.0",
+        "peer-info": "0.14.1",
+        "promisify-es6": "1.0.3",
+        "pull-defer": "0.2.2",
+        "pull-pushable": "2.2.0",
+        "pull-stream-to-stream": "1.3.4",
+        "pump": "3.0.0",
+        "qs": "6.5.2",
+        "readable-stream": "2.3.6",
+        "stream-http": "2.8.3",
+        "stream-to-pull-stream": "1.7.2",
+        "streamifier": "0.1.1",
+        "tar-stream": "1.6.1"
       }
     },
     "ipfs-bitswap": {
@@ -2595,29 +2578,29 @@
       "resolved": "https://registry.npmjs.org/ipfs-bitswap/-/ipfs-bitswap-0.20.3.tgz",
       "integrity": "sha512-qXg/QhevKBU/tKdWgW6yhcSKQDQx+4Mvv9HEeoVjkqZ9Pagmojk6yGk8X4J9H2G2PagvHXkWsqwqyKho7RcPWA==",
       "requires": {
-        "async": "^2.6.1",
-        "big.js": "^5.1.2",
-        "cids": "~0.5.3",
-        "debug": "^3.1.0",
-        "ipfs-block": "~0.7.1",
-        "lodash.debounce": "^4.0.8",
-        "lodash.find": "^4.6.0",
-        "lodash.groupby": "^4.6.0",
-        "lodash.isequalwith": "^4.4.0",
-        "lodash.isundefined": "^3.0.1",
-        "lodash.pullallwith": "^4.7.0",
-        "lodash.sortby": "^4.7.0",
-        "lodash.uniqwith": "^4.5.0",
-        "lodash.values": "^4.3.0",
-        "moving-average": "^1.0.0",
-        "multicodec": "~0.2.7",
-        "multihashing-async": "~0.5.1",
-        "protons": "^1.0.1",
-        "pull-defer": "~0.2.2",
-        "pull-length-prefixed": "^1.3.0",
-        "pull-pushable": "^2.2.0",
-        "pull-stream": "^3.6.8",
-        "varint-decoder": "~0.1.1"
+        "async": "2.6.1",
+        "big.js": "5.1.2",
+        "cids": "0.5.3",
+        "debug": "3.1.0",
+        "ipfs-block": "0.7.1",
+        "lodash.debounce": "4.0.8",
+        "lodash.find": "4.6.0",
+        "lodash.groupby": "4.6.0",
+        "lodash.isequalwith": "4.4.0",
+        "lodash.isundefined": "3.0.1",
+        "lodash.pullallwith": "4.7.0",
+        "lodash.sortby": "4.7.0",
+        "lodash.uniqwith": "4.5.0",
+        "lodash.values": "4.3.0",
+        "moving-average": "1.0.0",
+        "multicodec": "0.2.7",
+        "multihashing-async": "0.5.1",
+        "protons": "1.0.1",
+        "pull-defer": "0.2.2",
+        "pull-length-prefixed": "1.3.1",
+        "pull-pushable": "2.2.0",
+        "pull-stream": "3.6.8",
+        "varint-decoder": "0.1.1"
       }
     },
     "ipfs-block": {
@@ -2625,8 +2608,8 @@
       "resolved": "https://registry.npmjs.org/ipfs-block/-/ipfs-block-0.7.1.tgz",
       "integrity": "sha512-ABZS9J/+OaDwc10zu6pIVdxWnOD/rkPEravk7FRVuRep7/zKSjffNhO/WuHN7Ex+MOBMz7mty0e+i6xjGnRsRQ==",
       "requires": {
-        "cids": "^0.5.3",
-        "class-is": "^1.1.0"
+        "cids": "0.5.3",
+        "class-is": "1.1.0"
       }
     },
     "ipfs-block-service": {
@@ -2639,16 +2622,16 @@
       "resolved": "https://registry.npmjs.org/ipfs-http-response/-/ipfs-http-response-0.1.2.tgz",
       "integrity": "sha512-mJRFX3mlcv4yAxh0qMnlBuOyoB/3DiMj54sv12upubQckN0nPGJREldar8nHjVr4biuQKwyMPyxK5O1bK42UDQ==",
       "requires": {
-        "async": "^2.6.0",
-        "cids": "^0.5.3",
-        "debug": "^3.1.0",
-        "file-type": "^8.0.0",
-        "filesize": "^3.6.1",
-        "ipfs-unixfs": "^0.1.14",
-        "mime-types": "^2.1.18",
-        "multihashes": "^0.4.13",
-        "promisify-es6": "^1.0.3",
-        "readable-stream-node-to-web": "^1.0.1"
+        "async": "2.6.1",
+        "cids": "0.5.3",
+        "debug": "3.1.0",
+        "file-type": "8.1.0",
+        "filesize": "3.6.1",
+        "ipfs-unixfs": "0.1.15",
+        "mime-types": "2.1.19",
+        "multihashes": "0.4.13",
+        "promisify-es6": "1.0.3",
+        "readable-stream-node-to-web": "1.0.1"
       }
     },
     "ipfs-log": {
@@ -2656,8 +2639,8 @@
       "resolved": "https://registry.npmjs.org/ipfs-log/-/ipfs-log-4.1.2.tgz",
       "integrity": "sha512-YYP3vhoFgxGAZk1fzf72Wst0e6Y00GHslbNImkmxaQavNH0Qg5LFrmlNmlGEaRnl17z8vkrX8PKdgS8YnIvHzg==",
       "requires": {
-        "p-map": "^1.1.1",
-        "p-whilst": "^1.0.0"
+        "p-map": "1.2.0",
+        "p-whilst": "1.0.0"
       }
     },
     "ipfs-mfs": {
@@ -2665,31 +2648,31 @@
       "resolved": "https://registry.npmjs.org/ipfs-mfs/-/ipfs-mfs-0.1.0.tgz",
       "integrity": "sha512-vkgAykdAKim7eR+3uX/O6ocjgC6pFexrfwAKhr5ttljPuA0pQWnngFkumb4an/RORqdvOZBaUbN8lopFyBiWtw==",
       "requires": {
-        "async": "^2.6.1",
-        "blob": "~0.0.4",
-        "bs58": "^4.0.1",
-        "cids": "~0.5.3",
-        "debug": "^3.1.0",
-        "detect-node": "^2.0.3",
-        "file-api": "~0.10.4",
-        "filereader-stream": "^2.0.0",
-        "interface-datastore": "~0.4.2",
-        "ipfs-unixfs": "~0.1.15",
-        "ipfs-unixfs-engine": "~0.30.0",
-        "is-pull-stream": "~0.0.0",
-        "is-stream": "^1.1.0",
-        "joi": "^13.4.0",
-        "joi-browser": "^13.4.0",
-        "mortice": "^1.2.0",
-        "once": "^1.4.0",
-        "promisify-es6": "^1.0.3",
-        "pull-cat": "^1.1.11",
-        "pull-paramap": "^1.2.2",
-        "pull-pushable": "^2.2.0",
-        "pull-stream": "^3.6.7",
-        "pull-stream-to-stream": "^1.3.4",
-        "pull-traverse": "^1.0.3",
-        "stream-to-pull-stream": "^1.7.2"
+        "async": "2.6.1",
+        "blob": "0.0.4",
+        "bs58": "4.0.1",
+        "cids": "0.5.3",
+        "debug": "3.1.0",
+        "detect-node": "2.0.3",
+        "file-api": "0.10.4",
+        "filereader-stream": "2.0.0",
+        "interface-datastore": "0.4.2",
+        "ipfs-unixfs": "0.1.15",
+        "ipfs-unixfs-engine": "0.30.0",
+        "is-pull-stream": "0.0.0",
+        "is-stream": "1.1.0",
+        "joi": "13.4.0",
+        "joi-browser": "13.4.0",
+        "mortice": "1.2.1",
+        "once": "1.4.0",
+        "promisify-es6": "1.0.3",
+        "pull-cat": "1.1.11",
+        "pull-paramap": "1.2.2",
+        "pull-pushable": "2.2.0",
+        "pull-stream": "3.6.8",
+        "pull-stream-to-stream": "1.3.4",
+        "pull-traverse": "1.0.3",
+        "stream-to-pull-stream": "1.7.2"
       }
     },
     "ipfs-multipart": {
@@ -2697,8 +2680,8 @@
       "resolved": "https://registry.npmjs.org/ipfs-multipart/-/ipfs-multipart-0.1.0.tgz",
       "integrity": "sha1-Wo7RP0LoLYvvfS4VHY6vXjow4+o=",
       "requires": {
-        "content": "^3.0.0",
-        "dicer": "^0.2.5"
+        "content": "3.0.7",
+        "dicer": "0.2.5"
       }
     },
     "ipfs-pubsub-1on1": {
@@ -2706,7 +2689,7 @@
       "resolved": "https://registry.npmjs.org/ipfs-pubsub-1on1/-/ipfs-pubsub-1on1-0.0.4.tgz",
       "integrity": "sha512-q7xbxQpVdW6ISZw2KUTHnSdPE9LvK+YBzPmespYtGo/LwTEoPr8gz4dFazZUfixQaAP95ogY7Ir9q0NwPEw/yg==",
       "requires": {
-        "safe-buffer": "~5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "ipfs-pubsub-peer-monitor": {
@@ -2714,7 +2697,7 @@
       "resolved": "https://registry.npmjs.org/ipfs-pubsub-peer-monitor/-/ipfs-pubsub-peer-monitor-0.0.8.tgz",
       "integrity": "sha512-/6YJZn3dBbDUxopetJhgU65uAhOiz77CCTTZqEt4zk6s+r2t5+sYLIqO+1vX6IN3Bx2Hpf8iBdyt8JCkuq/zwg==",
       "requires": {
-        "p-forever": "^1.0.1"
+        "p-forever": "1.0.1"
       }
     },
     "ipfs-repo": {
@@ -2722,22 +2705,22 @@
       "resolved": "https://registry.npmjs.org/ipfs-repo/-/ipfs-repo-0.22.1.tgz",
       "integrity": "sha512-57RAHqbMMcVLEkbzx6PlMs7LnwsfMJrzjjNCNAsQuN2wcT8Abm09UIjo2P36x0leYMNIG2SWiyr1H5OLSKn74Q==",
       "requires": {
-        "async": "^2.6.0",
-        "base32.js": "~0.1.0",
-        "big.js": "^5.0.3",
-        "cids": "~0.5.3",
-        "datastore-core": "~0.4.0",
-        "datastore-fs": "~0.5.0",
-        "datastore-level": "~0.8.0",
-        "debug": "^3.1.0",
-        "interface-datastore": "~0.4.2",
-        "ipfs-block": "~0.7.1",
-        "lock-me": "^1.0.4",
-        "lodash.get": "^4.4.2",
-        "lodash.has": "^4.5.2",
-        "lodash.set": "^4.3.2",
-        "multiaddr": "^4.0.0",
-        "pull-stream": "^3.6.7"
+        "async": "2.6.1",
+        "base32.js": "0.1.0",
+        "big.js": "5.1.2",
+        "cids": "0.5.3",
+        "datastore-core": "0.4.0",
+        "datastore-fs": "0.5.0",
+        "datastore-level": "0.8.0",
+        "debug": "3.1.0",
+        "interface-datastore": "0.4.2",
+        "ipfs-block": "0.7.1",
+        "lock-me": "1.0.4",
+        "lodash.get": "4.4.2",
+        "lodash.has": "4.5.2",
+        "lodash.set": "4.3.2",
+        "multiaddr": "4.0.0",
+        "pull-stream": "3.6.8"
       },
       "dependencies": {
         "multiaddr": {
@@ -2745,14 +2728,14 @@
           "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-4.0.0.tgz",
           "integrity": "sha512-zUatrOCfBd/tJNOSoJ10d2EI2FDXB9PyPZhqUMdXE9mOyR3C+HLuOjga2Ga/eChwvEHIpTYRMoIKF2Nv7af2qQ==",
           "requires": {
-            "bs58": "^4.0.1",
-            "class-is": "^1.1.0",
-            "ip": "^1.1.5",
-            "ip-address": "^5.8.9",
-            "lodash.filter": "^4.6.0",
-            "lodash.map": "^4.6.0",
-            "varint": "^5.0.0",
-            "xtend": "^4.0.1"
+            "bs58": "4.0.1",
+            "class-is": "1.1.0",
+            "ip": "1.1.5",
+            "ip-address": "5.8.9",
+            "lodash.filter": "4.6.0",
+            "lodash.map": "4.6.0",
+            "varint": "5.0.0",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -2762,7 +2745,7 @@
       "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-0.1.15.tgz",
       "integrity": "sha512-fjtwBDsIlNags4btHIdAJtE02K4KqEMOhV9GEFVv1M2JO2STS23v2LAtX5qb1EOU5VrjtKlm/JIBH3XDRdAyGQ==",
       "requires": {
-        "protons": "^1.0.0"
+        "protons": "1.0.1"
       }
     },
     "ipfs-unixfs-engine": {
@@ -2770,29 +2753,29 @@
       "resolved": "https://registry.npmjs.org/ipfs-unixfs-engine/-/ipfs-unixfs-engine-0.30.0.tgz",
       "integrity": "sha512-IOrr9DfX8Sr0KqekTuBxKp+Y2+OLCKvsXM0+rlIOEFfZsdTQZTrHyJATVgCBDkJmrfvrHhKRYhO4BuGwYdHNfA==",
       "requires": {
-        "async": "^2.6.1",
-        "bs58": "^4.0.1",
-        "cids": "~0.5.3",
-        "deep-extend": "~0.6.0",
-        "ipfs-unixfs": "~0.1.15",
-        "ipld": "~0.17.2",
-        "ipld-dag-pb": "~0.14.4",
-        "left-pad": "^1.3.0",
-        "lodash": "^4.17.10",
-        "multihashes": "~0.4.13",
-        "multihashing-async": "~0.5.1",
-        "pull-batch": "^1.0.0",
-        "pull-block": "^1.4.0",
-        "pull-cat": "^1.1.11",
-        "pull-pair": "^1.1.0",
-        "pull-paramap": "^1.2.2",
+        "async": "2.6.1",
+        "bs58": "4.0.1",
+        "cids": "0.5.3",
+        "deep-extend": "0.6.0",
+        "ipfs-unixfs": "0.1.15",
+        "ipld": "0.17.3",
+        "ipld-dag-pb": "0.14.5",
+        "left-pad": "1.3.0",
+        "lodash": "4.17.10",
+        "multihashes": "0.4.13",
+        "multihashing-async": "0.5.1",
+        "pull-batch": "1.0.0",
+        "pull-block": "1.4.0",
+        "pull-cat": "1.1.11",
+        "pull-pair": "1.1.0",
+        "pull-paramap": "1.2.2",
         "pull-pause": "0.0.2",
-        "pull-pushable": "^2.2.0",
-        "pull-stream": "^3.6.8",
-        "pull-through": "^1.0.18",
-        "pull-traverse": "^1.0.3",
-        "pull-write": "^1.1.4",
-        "sparse-array": "^1.3.1"
+        "pull-pushable": "2.2.0",
+        "pull-stream": "3.6.8",
+        "pull-through": "1.0.18",
+        "pull-traverse": "1.0.3",
+        "pull-write": "1.1.4",
+        "sparse-array": "1.3.1"
       }
     },
     "ipld": {
@@ -2800,28 +2783,28 @@
       "resolved": "https://registry.npmjs.org/ipld/-/ipld-0.17.3.tgz",
       "integrity": "sha512-nUWbYfB59PTf/Hq0OEnitbR2hQb7k8/DOINpR6dXQ9MXVWh1cKxGs3ENOHuRr944T/ge2cJwI3XertcWqm0lXg==",
       "requires": {
-        "async": "^2.6.1",
-        "cids": "~0.5.3",
-        "interface-datastore": "~0.4.2",
-        "ipfs-block": "~0.7.1",
-        "ipfs-block-service": "~0.14.0",
-        "ipfs-repo": "~0.22.1",
-        "ipld-bitcoin": "~0.1.6",
-        "ipld-dag-cbor": "~0.12.1",
-        "ipld-dag-pb": "~0.14.5",
-        "ipld-ethereum": "^2.0.1",
-        "ipld-git": "~0.2.1",
-        "ipld-raw": "^2.0.1",
-        "ipld-zcash": "~0.1.4",
-        "is-ipfs": "~0.3.2",
-        "lodash.flatten": "^4.4.0",
-        "lodash.includes": "^4.3.0",
-        "memdown": "^3.0.0",
-        "multihashes": "~0.4.13",
-        "pull-defer": "~0.2.2",
-        "pull-sort": "^1.0.1",
-        "pull-stream": "^3.6.8",
-        "pull-traverse": "^1.0.3"
+        "async": "2.6.1",
+        "cids": "0.5.3",
+        "interface-datastore": "0.4.2",
+        "ipfs-block": "0.7.1",
+        "ipfs-block-service": "0.14.0",
+        "ipfs-repo": "0.22.1",
+        "ipld-bitcoin": "0.1.6",
+        "ipld-dag-cbor": "0.12.1",
+        "ipld-dag-pb": "0.14.5",
+        "ipld-ethereum": "2.0.1",
+        "ipld-git": "0.2.1",
+        "ipld-raw": "2.0.1",
+        "ipld-zcash": "0.1.4",
+        "is-ipfs": "0.3.2",
+        "lodash.flatten": "4.4.0",
+        "lodash.includes": "4.3.0",
+        "memdown": "3.0.0",
+        "multihashes": "0.4.13",
+        "pull-defer": "0.2.2",
+        "pull-sort": "1.0.1",
+        "pull-stream": "3.6.8",
+        "pull-traverse": "1.0.3"
       }
     },
     "ipld-bitcoin": {
@@ -2829,10 +2812,10 @@
       "resolved": "https://registry.npmjs.org/ipld-bitcoin/-/ipld-bitcoin-0.1.6.tgz",
       "integrity": "sha512-WqF3u8nEsk94dfpTZUHXHlnscWBSTs8i02VpJmWIjugcqYZeZzjgeMS5Q2dNTDNzuKshmvjQJa3ubpSkWo3XwA==",
       "requires": {
-        "bitcoinjs-lib": "^3.3.2",
-        "cids": "~0.5.2",
-        "multihashes": "~0.4.12",
-        "multihashing-async": "~0.5.1"
+        "bitcoinjs-lib": "3.3.2",
+        "cids": "0.5.3",
+        "multihashes": "0.4.13",
+        "multihashing-async": "0.5.1"
       }
     },
     "ipld-dag-cbor": {
@@ -2840,14 +2823,14 @@
       "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.12.1.tgz",
       "integrity": "sha512-m0BR/zR9sKIuY/PydppkpwO0S9w7+ob0as7RN3jQmMIpW9m8HW7hLznvtp1xpYZknH7efUhIaMHgaQP43E5IWQ==",
       "requires": {
-        "async": "^2.6.0",
-        "borc": "^2.0.2",
-        "bs58": "^4.0.1",
-        "cids": "~0.5.2",
-        "is-circular": "^1.0.1",
-        "multihashes": "~0.4.12",
-        "multihashing-async": "~0.5.1",
-        "traverse": "~0.6.6"
+        "async": "2.6.1",
+        "borc": "2.0.3",
+        "bs58": "4.0.1",
+        "cids": "0.5.3",
+        "is-circular": "1.0.2",
+        "multihashes": "0.4.13",
+        "multihashing-async": "0.5.1",
+        "traverse": "0.6.6"
       }
     },
     "ipld-dag-pb": {
@@ -2855,18 +2838,18 @@
       "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.14.5.tgz",
       "integrity": "sha512-HHKqyjP1m9PxbT1+EWrbq/dH6uIY90mvwQ6G79JWKsdCsyOvRbyCdmZmXbbuTN9JBFcoMG2684qix+HtiEz0fQ==",
       "requires": {
-        "async": "^2.6.1",
-        "bs58": "^4.0.1",
-        "buffer-loader": "~0.0.1",
-        "cids": "~0.5.3",
-        "class-is": "^1.1.0",
-        "is-ipfs": "~0.3.2",
-        "multihashes": "~0.4.13",
-        "multihashing-async": "~0.5.1",
-        "protons": "^1.0.1",
-        "pull-stream": "^3.6.8",
-        "pull-traverse": "^1.0.3",
-        "stable": "~0.1.8"
+        "async": "2.6.1",
+        "bs58": "4.0.1",
+        "buffer-loader": "0.0.1",
+        "cids": "0.5.3",
+        "class-is": "1.1.0",
+        "is-ipfs": "0.3.2",
+        "multihashes": "0.4.13",
+        "multihashing-async": "0.5.1",
+        "protons": "1.0.1",
+        "pull-stream": "3.6.8",
+        "pull-traverse": "1.0.3",
+        "stable": "0.1.8"
       }
     },
     "ipld-ethereum": {
@@ -2874,16 +2857,16 @@
       "resolved": "https://registry.npmjs.org/ipld-ethereum/-/ipld-ethereum-2.0.1.tgz",
       "integrity": "sha512-p+OIsTg7+NeXnE2Uq7g5HV7KVbJTQ9kVHSywOAUxUfj6loJb+6ReTCRrayQ+SbIXuVVVIVPU8OOUoGaugwFEjg==",
       "requires": {
-        "async": "^2.6.0",
-        "cids": "~0.5.2",
-        "ethereumjs-account": "^2.0.4",
-        "ethereumjs-block": "^1.7.1",
-        "ethereumjs-tx": "^1.3.3",
-        "ipfs-block": "~0.6.1",
-        "merkle-patricia-tree": "^2.2.0",
-        "multihashes": "~0.4.12",
-        "multihashing-async": "~0.4.7",
-        "rlp": "^2.0.0"
+        "async": "2.6.1",
+        "cids": "0.5.3",
+        "ethereumjs-account": "2.0.5",
+        "ethereumjs-block": "1.7.1",
+        "ethereumjs-tx": "1.3.6",
+        "ipfs-block": "0.6.1",
+        "merkle-patricia-tree": "2.3.1",
+        "multihashes": "0.4.13",
+        "multihashing-async": "0.4.8",
+        "rlp": "2.1.0"
       },
       "dependencies": {
         "ipfs-block": {
@@ -2891,7 +2874,7 @@
           "resolved": "https://registry.npmjs.org/ipfs-block/-/ipfs-block-0.6.1.tgz",
           "integrity": "sha512-28dgGsb2YsYnFs+To4cVBX8e/lTCb8eWDzGhN5csj3a/sHMOYrHeK8+Ez0IV67CI3lqKGuG/ZD01Cmd6JUvKrQ==",
           "requires": {
-            "cids": "^0.5.2"
+            "cids": "0.5.3"
           }
         },
         "multihashing-async": {
@@ -2899,12 +2882,12 @@
           "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
           "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
           "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
+            "async": "2.6.1",
+            "blakejs": "1.1.0",
+            "js-sha3": "0.7.0",
+            "multihashes": "0.4.13",
+            "murmurhash3js": "3.0.1",
+            "nodeify": "1.0.1"
           }
         }
       }
@@ -2914,13 +2897,13 @@
       "resolved": "https://registry.npmjs.org/ipld-git/-/ipld-git-0.2.1.tgz",
       "integrity": "sha512-DjCgL6n8vFRyjoyjt6BVMHWy9S9XaOHD+IDvnoeZU0oMRd68B3Y/heTI0HStMxrOhR8VNhjH5W+EpJ3823BAYQ==",
       "requires": {
-        "async": "^2.6.0",
-        "cids": "~0.5.2",
-        "multicodec": "~0.2.5",
-        "multihashes": "~0.4.12",
-        "multihashing-async": "~0.5.1",
-        "smart-buffer": "^4.0.0",
-        "traverse": "~0.6.6"
+        "async": "2.6.1",
+        "cids": "0.5.3",
+        "multicodec": "0.2.7",
+        "multihashes": "0.4.13",
+        "multihashing-async": "0.5.1",
+        "smart-buffer": "4.0.1",
+        "traverse": "0.6.6"
       }
     },
     "ipld-raw": {
@@ -2928,8 +2911,8 @@
       "resolved": "https://registry.npmjs.org/ipld-raw/-/ipld-raw-2.0.1.tgz",
       "integrity": "sha512-wtP1I61YQoAPnRZqVeflrxjTi41+38ck2puEz9mnMlc0ChYRGc4ZSKcWDTk66EQuqEzDAdV71nOMKb3JzDfbsg==",
       "requires": {
-        "cids": "~0.5.2",
-        "multihashing-async": "~0.5.1"
+        "cids": "0.5.3",
+        "multihashing-async": "0.5.1"
       }
     },
     "ipld-zcash": {
@@ -2937,11 +2920,11 @@
       "resolved": "https://registry.npmjs.org/ipld-zcash/-/ipld-zcash-0.1.4.tgz",
       "integrity": "sha512-KjwuRH0VHPY+SPjTD1lYL3XzMfQyIeCRH+Jkq1z5kSmX0IjNe4riVzUPGySD+R1ITewSDGvnCoTeyNwK/dIrEg==",
       "requires": {
-        "cids": "~0.5.2",
-        "dirty-chai": "^2.0.1",
-        "multihashes": "~0.4.12",
-        "multihashing-async": "~0.5.1",
-        "zcash-bitcore-lib": "~0.13.20-rc3"
+        "cids": "0.5.3",
+        "dirty-chai": "2.0.1",
+        "multihashes": "0.4.13",
+        "multihashing-async": "0.5.1",
+        "zcash-bitcore-lib": "0.13.20-rc3"
       }
     },
     "iron": {
@@ -2949,9 +2932,9 @@
       "resolved": "https://registry.npmjs.org/iron/-/iron-4.0.5.tgz",
       "integrity": "sha1-TwQszri5c480a1mqc0yDqJvDFCg=",
       "requires": {
-        "boom": "5.x.x",
-        "cryptiles": "3.x.x",
-        "hoek": "4.x.x"
+        "boom": "5.2.0",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.1"
       },
       "dependencies": {
         "boom": {
@@ -2959,7 +2942,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "4.2.1"
           }
         },
         "hoek": {
@@ -2979,7 +2962,7 @@
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "requires": {
-        "builtin-modules": "^1.0.0"
+        "builtin-modules": "1.1.1"
       }
     },
     "is-ci": {
@@ -2987,7 +2970,7 @@
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
       "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
       "requires": {
-        "ci-info": "^1.0.0"
+        "ci-info": "1.1.3"
       }
     },
     "is-circular": {
@@ -3000,7 +2983,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-hex-prefixed": {
@@ -3013,8 +2996,8 @@
       "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
       "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
       "requires": {
-        "global-dirs": "^0.1.0",
-        "is-path-inside": "^1.0.0"
+        "global-dirs": "0.1.1",
+        "is-path-inside": "1.0.1"
       }
     },
     "is-ipfs": {
@@ -3022,9 +3005,9 @@
       "resolved": "https://registry.npmjs.org/is-ipfs/-/is-ipfs-0.3.2.tgz",
       "integrity": "sha512-82V1j4LMkYy7H4seQQzOWqo7FiW3I64/1/ryo3dhtWKfOvm7ZolLMRQQfGKs4OXWauh5rAkPnamVcRISHwhmpQ==",
       "requires": {
-        "bs58": "^4.0.1",
-        "cids": "~0.5.1",
-        "multihashes": "~0.4.9"
+        "bs58": "4.0.1",
+        "cids": "0.5.3",
+        "multihashes": "0.4.13"
       }
     },
     "is-npm": {
@@ -3042,7 +3025,7 @@
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "requires": {
-        "path-is-inside": "^1.0.1"
+        "path-is-inside": "1.0.2"
       }
     },
     "is-promise": {
@@ -3105,9 +3088,9 @@
       "resolved": "https://registry.npmjs.org/joi/-/joi-13.4.0.tgz",
       "integrity": "sha512-JuK4GjEu6j7zr9FuVe2MAseZ6si/8/HaY0qMAejfDFHp7jcH4OKE937mIHM5VT4xDS0q7lpQbszbxKV9rm0yUg==",
       "requires": {
-        "hoek": "5.x.x",
-        "isemail": "3.x.x",
-        "topo": "3.x.x"
+        "hoek": "5.0.3",
+        "isemail": "3.1.3",
+        "topo": "3.0.0"
       },
       "dependencies": {
         "isemail": {
@@ -3115,7 +3098,7 @@
           "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.3.tgz",
           "integrity": "sha512-5xbsG5wYADIcB+mfLsd+nst1V/D+I7EU7LEZPo2GOIMu4JzfcRs5yQoypP4avA7QtUqgxYLKBYNv4IdzBmbhdw==",
           "requires": {
-            "punycode": "2.x.x"
+            "punycode": "2.1.1"
           }
         },
         "topo": {
@@ -3123,7 +3106,7 @@
           "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.0.tgz",
           "integrity": "sha512-Tlu1fGlR90iCdIPURqPiufqAlCZYzLjHYVVbcFWDMcX7+tK8hdZWAfsMrD/pBul9jqHHwFjNdf1WaxA9vTRRhw==",
           "requires": {
-            "hoek": "5.x.x"
+            "hoek": "5.0.3"
           }
         }
       }
@@ -3138,8 +3121,8 @@
       "resolved": "https://registry.npmjs.org/joi-multiaddr/-/joi-multiaddr-2.0.0.tgz",
       "integrity": "sha512-7dJLwgplwRnIQAlC+zTuX3jkk3uXVa/RKm7GDfNO3NqmjiYgwAet8yprIdilki1WhdkJJMLuTNDf49uFNru68A==",
       "requires": {
-        "mafmt": "^6.0.0",
-        "multiaddr": "^4.0.0"
+        "mafmt": "6.0.0",
+        "multiaddr": "4.0.0"
       },
       "dependencies": {
         "multiaddr": {
@@ -3147,14 +3130,14 @@
           "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-4.0.0.tgz",
           "integrity": "sha512-zUatrOCfBd/tJNOSoJ10d2EI2FDXB9PyPZhqUMdXE9mOyR3C+HLuOjga2Ga/eChwvEHIpTYRMoIKF2Nv7af2qQ==",
           "requires": {
-            "bs58": "^4.0.1",
-            "class-is": "^1.1.0",
-            "ip": "^1.1.5",
-            "ip-address": "^5.8.9",
-            "lodash.filter": "^4.6.0",
-            "lodash.map": "^4.6.0",
-            "varint": "^5.0.0",
-            "xtend": "^4.0.1"
+            "bs58": "4.0.1",
+            "class-is": "1.1.0",
+            "ip": "1.1.5",
+            "ip-address": "5.8.9",
+            "lodash.filter": "4.6.0",
+            "lodash.map": "4.6.0",
+            "varint": "5.0.0",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -3192,8 +3175,8 @@
       "resolved": "https://registry.npmjs.org/k-bucket/-/k-bucket-4.0.1.tgz",
       "integrity": "sha512-YvDpmY3waI999h1zZoW1rJ04fZrgZ+5PAlVmvwDHT6YO/Q1AOhdel07xsKy9eAvJjQ9xZV1wz3rXKqEfaWvlcQ==",
       "requires": {
-        "inherits": "^2.0.1",
-        "randombytes": "^2.0.3"
+        "inherits": "2.0.3",
+        "randombytes": "2.0.6"
       }
     },
     "keccak": {
@@ -3201,10 +3184,10 @@
       "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
       "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
       "requires": {
-        "bindings": "^1.2.1",
-        "inherits": "^2.0.3",
-        "nan": "^2.2.1",
-        "safe-buffer": "^5.1.0"
+        "bindings": "1.3.0",
+        "inherits": "2.0.3",
+        "nan": "2.10.0",
+        "safe-buffer": "5.1.2"
       }
     },
     "keypair": {
@@ -3217,8 +3200,8 @@
       "resolved": "https://registry.npmjs.org/latency-monitor/-/latency-monitor-0.2.1.tgz",
       "integrity": "sha1-QEPV8j3obiv872ztSjtbki4d1+0=",
       "requires": {
-        "debug": "^2.6.0",
-        "lodash": "^4.17.4"
+        "debug": "2.6.9",
+        "lodash": "4.17.10"
       },
       "dependencies": {
         "debug": {
@@ -3236,7 +3219,7 @@
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
       "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
       "requires": {
-        "package-json": "^4.0.0"
+        "package-json": "4.0.1"
       }
     },
     "lcid": {
@@ -3244,7 +3227,7 @@
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "requires": {
-        "invert-kv": "^1.0.0"
+        "invert-kv": "1.0.0"
       }
     },
     "left-pad": {
@@ -3257,9 +3240,9 @@
       "resolved": "https://registry.npmjs.org/length-prefixed-stream/-/length-prefixed-stream-1.6.0.tgz",
       "integrity": "sha512-gsJvrb5giDqil/ScQ7fEoplsI2Ch4DwnvnfTW2EGl9KBW6Ekzn8JSNESObqNAeZD8HkSjEMvc5XjhuB66fsSZQ==",
       "requires": {
-        "buffer-alloc-unsafe": "^1.0.0",
-        "readable-stream": "^2.0.0",
-        "varint": "^5.0.0"
+        "buffer-alloc-unsafe": "1.1.0",
+        "readable-stream": "2.3.6",
+        "varint": "5.0.0"
       }
     },
     "level-codec": {
@@ -3272,7 +3255,7 @@
       "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.0.tgz",
       "integrity": "sha512-AmY4HCp9h3OiU19uG+3YWkdELgy05OTP/r23aNHaQKWv8DO787yZgsEuGVkoph40uwN+YdUKnANlrxSsoOaaxg==",
       "requires": {
-        "errno": "~0.1.1"
+        "errno": "0.1.7"
       }
     },
     "level-iterator-stream": {
@@ -3280,29 +3263,9 @@
       "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.3.tgz",
       "integrity": "sha512-I6Heg70nfF+e5Y3/qfthJFexhRw/Gi3bIymCoXAlijZdAcLaPuWSJs3KXyTYf23ID6g0o2QF62Yh+grOXY3Rig==",
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.5",
-        "xtend": "^4.0.0"
-      }
-    },
-    "level-js": {
-      "version": "github:timkuijsten/level.js#18e03adab34c49523be7d3d58fafb0c632f61303",
-      "from": "github:timkuijsten/level.js#idbunwrapper",
-      "requires": {
-        "abstract-leveldown": "~2.4.1",
-        "idb-readable-stream": "0.0.4",
-        "ltgt": "^2.1.2",
-        "xtend": "^4.0.1"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.4.1.tgz",
-          "integrity": "sha1-s7/tuITraToSd18MVenwpCDM7mQ=",
-          "requires": {
-            "xtend": "~4.0.0"
-          }
-        }
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "xtend": "4.0.1"
       }
     },
     "level-ws": {
@@ -3310,8 +3273,8 @@
       "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
       "integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
       "requires": {
-        "readable-stream": "~1.0.15",
-        "xtend": "~2.1.1"
+        "readable-stream": "1.0.34",
+        "xtend": "2.1.2"
       },
       "dependencies": {
         "isarray": {
@@ -3324,10 +3287,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -3340,7 +3303,7 @@
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
           "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
           "requires": {
-            "object-keys": "~0.4.0"
+            "object-keys": "0.4.0"
           }
         }
       }
@@ -3350,11 +3313,11 @@
       "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-3.0.2.tgz",
       "integrity": "sha512-+ANRScj1npQQzv6e4DYAKRjVQZZ+ahMoubKrNP68nIq+l9bYgb+WiXF+14oTcQTg2f7qE9WHGW7rBG9nGSsA+A==",
       "requires": {
-        "abstract-leveldown": "~4.0.0",
-        "bindings": "~1.3.0",
-        "fast-future": "~1.0.2",
-        "nan": "~2.10.0",
-        "prebuild-install": "^4.0.0"
+        "abstract-leveldown": "4.0.3",
+        "bindings": "1.3.0",
+        "fast-future": "1.0.2",
+        "nan": "2.10.0",
+        "prebuild-install": "4.0.0"
       },
       "dependencies": {
         "abstract-leveldown": {
@@ -3362,7 +3325,7 @@
           "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-4.0.3.tgz",
           "integrity": "sha512-qsIHFQy0u17JqSY+3ZUT+ykqxYY17yOfvAsLkFkw8kSQqi05d1jyj0bCuSX6sjYlXuY9cKpgUt5EudQdP4aXyA==",
           "requires": {
-            "xtend": "~4.0.0"
+            "xtend": "4.0.1"
           }
         }
       }
@@ -3372,10 +3335,10 @@
       "resolved": "https://registry.npmjs.org/levelup/-/levelup-2.0.2.tgz",
       "integrity": "sha512-us+nTLUyd/eLnclYYddOCdAVw1hnymGx/9p4Jr5ThohStsjLqMVmbYiz6/SYFZEPXNF+AKQSvh6fA2e2KZpC8w==",
       "requires": {
-        "deferred-leveldown": "~3.0.0",
-        "level-errors": "~1.1.0",
-        "level-iterator-stream": "~2.0.0",
-        "xtend": "~4.0.0"
+        "deferred-leveldown": "3.0.0",
+        "level-errors": "1.1.2",
+        "level-iterator-stream": "2.0.3",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "level-errors": {
@@ -3383,7 +3346,7 @@
           "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.1.2.tgz",
           "integrity": "sha512-Sw/IJwWbPKF5Ai4Wz60B52yj0zYeqzObLh8k1Tk88jVmD51cJSKWSYpRyhVIvFzZdvsPqlH5wfhp/yxdsaQH4w==",
           "requires": {
-            "errno": "~0.1.1"
+            "errno": "0.1.7"
           }
         }
       }
@@ -3393,19 +3356,19 @@
       "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.22.0.tgz",
       "integrity": "sha512-7CcituMkZc4OcsXs1yjBnLDCjXl3OlDB6A6NgjRLOWplb2VnyR1RSU4kpUmslcE7BvKKNqSeDd/QzBwcPp7prg==",
       "requires": {
-        "async": "^2.6.1",
-        "joi": "^13.4.0",
-        "joi-browser": "^13.4.0",
-        "libp2p-connection-manager": "~0.0.2",
-        "libp2p-floodsub": "~0.15.0",
-        "libp2p-ping": "~0.8.0",
-        "libp2p-switch": "~0.40.4",
-        "libp2p-websockets": "~0.12.0",
-        "mafmt": "^6.0.0",
-        "multiaddr": "^5.0.0",
-        "peer-book": "~0.8.0",
-        "peer-id": "~0.10.7",
-        "peer-info": "~0.14.1"
+        "async": "2.6.1",
+        "joi": "13.4.0",
+        "joi-browser": "13.4.0",
+        "libp2p-connection-manager": "0.0.2",
+        "libp2p-floodsub": "0.15.0",
+        "libp2p-ping": "0.8.0",
+        "libp2p-switch": "0.40.6",
+        "libp2p-websockets": "0.12.0",
+        "mafmt": "6.0.0",
+        "multiaddr": "5.0.0",
+        "peer-book": "0.8.0",
+        "peer-id": "0.10.7",
+        "peer-info": "0.14.1"
       },
       "dependencies": {
         "libp2p-crypto": {
@@ -3413,19 +3376,18 @@
           "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
           "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
           "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.1.1",
-            "bs58": "^4.0.1",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.7",
-            "node-forge": "^0.7.1",
-            "pem-jwk": "^1.5.1",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+            "asn1.js": "5.0.1",
+            "async": "2.6.1",
+            "browserify-aes": "1.2.0",
+            "bs58": "4.0.1",
+            "keypair": "1.0.1",
+            "libp2p-crypto-secp256k1": "0.2.2",
+            "multihashing-async": "0.4.8",
+            "node-forge": "0.7.5",
+            "pem-jwk": "1.5.1",
+            "protons": "1.0.1",
+            "rsa-pem-to-jwk": "1.1.3",
+            "tweetnacl": "1.0.0"
           }
         },
         "multihashing-async": {
@@ -3433,12 +3395,12 @@
           "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
           "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
           "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
+            "async": "2.6.1",
+            "blakejs": "1.1.0",
+            "js-sha3": "0.7.0",
+            "multihashes": "0.4.13",
+            "murmurhash3js": "3.0.1",
+            "nodeify": "1.0.1"
           }
         },
         "peer-id": {
@@ -3446,10 +3408,10 @@
           "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
           "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
           "requires": {
-            "async": "^2.6.0",
-            "libp2p-crypto": "~0.12.1",
-            "lodash": "^4.17.5",
-            "multihashes": "~0.4.13"
+            "async": "2.6.1",
+            "libp2p-crypto": "0.12.1",
+            "lodash": "4.17.10",
+            "multihashes": "0.4.13"
           }
         }
       }
@@ -3459,12 +3421,12 @@
       "resolved": "https://registry.npmjs.org/libp2p-bootstrap/-/libp2p-bootstrap-0.9.3.tgz",
       "integrity": "sha512-rEVvZZCKmoJlfgSMk7JkuvsdKGpLkoPK3U47xtT+pNJC+p/LZcjSmGwxNwwJvgg3jTuy2sl23W6JRZ26AXv7Og==",
       "requires": {
-        "async": "^2.6.1",
-        "debug": "^3.1.0",
-        "mafmt": "^6.0.0",
-        "multiaddr": "^5.0.0",
-        "peer-id": "~0.10.7",
-        "peer-info": "~0.14.1"
+        "async": "2.6.1",
+        "debug": "3.1.0",
+        "mafmt": "6.0.0",
+        "multiaddr": "5.0.0",
+        "peer-id": "0.10.7",
+        "peer-info": "0.14.1"
       },
       "dependencies": {
         "libp2p-crypto": {
@@ -3472,19 +3434,18 @@
           "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
           "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
           "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.1.1",
-            "bs58": "^4.0.1",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.7",
-            "node-forge": "^0.7.1",
-            "pem-jwk": "^1.5.1",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+            "asn1.js": "5.0.1",
+            "async": "2.6.1",
+            "browserify-aes": "1.2.0",
+            "bs58": "4.0.1",
+            "keypair": "1.0.1",
+            "libp2p-crypto-secp256k1": "0.2.2",
+            "multihashing-async": "0.4.8",
+            "node-forge": "0.7.5",
+            "pem-jwk": "1.5.1",
+            "protons": "1.0.1",
+            "rsa-pem-to-jwk": "1.1.3",
+            "tweetnacl": "1.0.0"
           }
         },
         "multihashing-async": {
@@ -3492,12 +3453,12 @@
           "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
           "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
           "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
+            "async": "2.6.1",
+            "blakejs": "1.1.0",
+            "js-sha3": "0.7.0",
+            "multihashes": "0.4.13",
+            "murmurhash3js": "3.0.1",
+            "nodeify": "1.0.1"
           }
         },
         "peer-id": {
@@ -3505,10 +3466,10 @@
           "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
           "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
           "requires": {
-            "async": "^2.6.0",
-            "libp2p-crypto": "~0.12.1",
-            "lodash": "^4.17.5",
-            "multihashes": "~0.4.13"
+            "async": "2.6.1",
+            "libp2p-crypto": "0.12.1",
+            "lodash": "4.17.10",
+            "multihashes": "0.4.13"
           }
         }
       }
@@ -3518,22 +3479,22 @@
       "resolved": "https://registry.npmjs.org/libp2p-circuit/-/libp2p-circuit-0.2.0.tgz",
       "integrity": "sha512-K3k+ojqO8b1VM1C2Nb+ba+8z7lDD1pn6stieIB3pOEB35M9pVbXfVg8nKoSnjw3NAXCSsSCbD1swYMwq8g/fAA==",
       "requires": {
-        "assert": "^1.4.1",
-        "async": "^2.6.0",
-        "debug": "^3.1.0",
-        "interface-connection": "^0.3.2",
-        "lodash": "^4.17.5",
-        "mafmt": "^6.0.0",
-        "multiaddr": "^4.0.0",
-        "multistream-select": "^0.14.1",
-        "peer-id": "^0.10.7",
-        "peer-info": "^0.14.0",
-        "protons": "^1.0.1",
-        "pull-abortable": "^4.1.1",
-        "pull-handshake": "^1.1.4",
-        "pull-stream": "^3.6.7",
-        "safe-buffer": "^5.1.1",
-        "setimmediate": "^1.0.5"
+        "assert": "1.4.1",
+        "async": "2.6.1",
+        "debug": "3.1.0",
+        "interface-connection": "0.3.2",
+        "lodash": "4.17.10",
+        "mafmt": "6.0.0",
+        "multiaddr": "4.0.0",
+        "multistream-select": "0.14.2",
+        "peer-id": "0.10.7",
+        "peer-info": "0.14.1",
+        "protons": "1.0.1",
+        "pull-abortable": "4.1.1",
+        "pull-handshake": "1.1.4",
+        "pull-stream": "3.6.8",
+        "safe-buffer": "5.1.2",
+        "setimmediate": "1.0.5"
       },
       "dependencies": {
         "libp2p-crypto": {
@@ -3541,19 +3502,18 @@
           "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
           "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
           "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.1.1",
-            "bs58": "^4.0.1",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.7",
-            "node-forge": "^0.7.1",
-            "pem-jwk": "^1.5.1",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+            "asn1.js": "5.0.1",
+            "async": "2.6.1",
+            "browserify-aes": "1.2.0",
+            "bs58": "4.0.1",
+            "keypair": "1.0.1",
+            "libp2p-crypto-secp256k1": "0.2.2",
+            "multihashing-async": "0.4.8",
+            "node-forge": "0.7.5",
+            "pem-jwk": "1.5.1",
+            "protons": "1.0.1",
+            "rsa-pem-to-jwk": "1.1.3",
+            "tweetnacl": "1.0.0"
           }
         },
         "multiaddr": {
@@ -3561,14 +3521,14 @@
           "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-4.0.0.tgz",
           "integrity": "sha512-zUatrOCfBd/tJNOSoJ10d2EI2FDXB9PyPZhqUMdXE9mOyR3C+HLuOjga2Ga/eChwvEHIpTYRMoIKF2Nv7af2qQ==",
           "requires": {
-            "bs58": "^4.0.1",
-            "class-is": "^1.1.0",
-            "ip": "^1.1.5",
-            "ip-address": "^5.8.9",
-            "lodash.filter": "^4.6.0",
-            "lodash.map": "^4.6.0",
-            "varint": "^5.0.0",
-            "xtend": "^4.0.1"
+            "bs58": "4.0.1",
+            "class-is": "1.1.0",
+            "ip": "1.1.5",
+            "ip-address": "5.8.9",
+            "lodash.filter": "4.6.0",
+            "lodash.map": "4.6.0",
+            "varint": "5.0.0",
+            "xtend": "4.0.1"
           }
         },
         "multihashing-async": {
@@ -3576,12 +3536,12 @@
           "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
           "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
           "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
+            "async": "2.6.1",
+            "blakejs": "1.1.0",
+            "js-sha3": "0.7.0",
+            "multihashes": "0.4.13",
+            "murmurhash3js": "3.0.1",
+            "nodeify": "1.0.1"
           }
         },
         "peer-id": {
@@ -3589,10 +3549,10 @@
           "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
           "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
           "requires": {
-            "async": "^2.6.0",
-            "libp2p-crypto": "~0.12.1",
-            "lodash": "^4.17.5",
-            "multihashes": "~0.4.13"
+            "async": "2.6.1",
+            "libp2p-crypto": "0.12.1",
+            "lodash": "4.17.10",
+            "multihashes": "0.4.13"
           }
         }
       }
@@ -3602,8 +3562,8 @@
       "resolved": "https://registry.npmjs.org/libp2p-connection-manager/-/libp2p-connection-manager-0.0.2.tgz",
       "integrity": "sha512-G/OzMfxQe0lHx7ujibPqpFLCeMN9I5vNH0+Rs9zat6+uIT51Saupx95lyoyh5J8nh93ui2cNH7PQnwJMZVKa1A==",
       "requires": {
-        "debug": "^3.1.0",
-        "latency-monitor": "^0.2.1"
+        "debug": "3.1.0",
+        "latency-monitor": "0.2.1"
       }
     },
     "libp2p-crypto": {
@@ -3611,19 +3571,18 @@
       "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.13.0.tgz",
       "integrity": "sha512-i3r1TBec/xYmC5bcpPiIs3OyUAU3iy53OdRdxqawKoWTQPjYB+TyQ4w+otT66Y0sMcw70O0wH3GFAfPmQgFn+g==",
       "requires": {
-        "asn1.js": "^5.0.0",
-        "async": "^2.6.0",
-        "browserify-aes": "^1.2.0",
-        "bs58": "^4.0.1",
-        "keypair": "^1.0.1",
-        "libp2p-crypto-secp256k1": "~0.2.2",
-        "multihashing-async": "~0.4.8",
-        "node-forge": "^0.7.5",
-        "pem-jwk": "^1.5.1",
-        "protons": "^1.0.1",
-        "rsa-pem-to-jwk": "^1.1.3",
-        "tweetnacl": "^1.0.0",
-        "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+        "asn1.js": "5.0.1",
+        "async": "2.6.1",
+        "browserify-aes": "1.2.0",
+        "bs58": "4.0.1",
+        "keypair": "1.0.1",
+        "libp2p-crypto-secp256k1": "0.2.2",
+        "multihashing-async": "0.4.8",
+        "node-forge": "0.7.5",
+        "pem-jwk": "1.5.1",
+        "protons": "1.0.1",
+        "rsa-pem-to-jwk": "1.1.3",
+        "tweetnacl": "1.0.0"
       },
       "dependencies": {
         "multihashing-async": {
@@ -3631,12 +3590,12 @@
           "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
           "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
           "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
+            "async": "2.6.1",
+            "blakejs": "1.1.0",
+            "js-sha3": "0.7.0",
+            "multihashes": "0.4.13",
+            "murmurhash3js": "3.0.1",
+            "nodeify": "1.0.1"
           }
         }
       }
@@ -3646,11 +3605,11 @@
       "resolved": "https://registry.npmjs.org/libp2p-crypto-secp256k1/-/libp2p-crypto-secp256k1-0.2.2.tgz",
       "integrity": "sha1-DdUh8Yq8TjahUuJOmzYwewrpzwU=",
       "requires": {
-        "async": "^2.5.0",
-        "multihashing-async": "~0.4.6",
-        "nodeify": "^1.0.1",
-        "safe-buffer": "^5.1.1",
-        "secp256k1": "^3.3.0"
+        "async": "2.6.1",
+        "multihashing-async": "0.4.8",
+        "nodeify": "1.0.1",
+        "safe-buffer": "5.1.2",
+        "secp256k1": "3.5.0"
       },
       "dependencies": {
         "multihashing-async": {
@@ -3658,12 +3617,12 @@
           "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
           "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
           "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
+            "async": "2.6.1",
+            "blakejs": "1.1.0",
+            "js-sha3": "0.7.0",
+            "multihashes": "0.4.13",
+            "murmurhash3js": "3.0.1",
+            "nodeify": "1.0.1"
           }
         }
       }
@@ -3673,15 +3632,15 @@
       "resolved": "https://registry.npmjs.org/libp2p-floodsub/-/libp2p-floodsub-0.15.0.tgz",
       "integrity": "sha512-sDVNxE6GKOZ7+qWE06jQuJ/CrYgPfOqkRD4qWPFe02AtghswyocWJkDiceKHx++mW2h2KYl7ae68XK0DLEEOiw==",
       "requires": {
-        "async": "^2.6.0",
-        "bs58": "^4.0.1",
-        "debug": "^3.1.0",
-        "length-prefixed-stream": "^1.5.2",
-        "libp2p-crypto": "~0.13.0",
-        "lodash.values": "^4.3.0",
-        "protons": "^1.0.1",
-        "pull-pushable": "^2.2.0",
-        "time-cache": "~0.3.0"
+        "async": "2.6.1",
+        "bs58": "4.0.1",
+        "debug": "3.1.0",
+        "length-prefixed-stream": "1.6.0",
+        "libp2p-crypto": "0.13.0",
+        "lodash.values": "4.3.0",
+        "protons": "1.0.1",
+        "pull-pushable": "2.2.0",
+        "time-cache": "0.3.0"
       }
     },
     "libp2p-identify": {
@@ -3689,12 +3648,12 @@
       "resolved": "https://registry.npmjs.org/libp2p-identify/-/libp2p-identify-0.7.1.tgz",
       "integrity": "sha512-uQh04s5s2v6JbhdzeKdQqaOGmEMlZv60djMR74MPkerNPFLcJEHHyVXcD35CgMVaZezqai2Y8L2zvPuuOnUZtA==",
       "requires": {
-        "multiaddr": "^5.0.0",
-        "peer-id": "~0.10.7",
-        "peer-info": "~0.14.1",
-        "protons": "^1.0.1",
-        "pull-length-prefixed": "^1.3.0",
-        "pull-stream": "^3.6.7"
+        "multiaddr": "5.0.0",
+        "peer-id": "0.10.7",
+        "peer-info": "0.14.1",
+        "protons": "1.0.1",
+        "pull-length-prefixed": "1.3.1",
+        "pull-stream": "3.6.8"
       },
       "dependencies": {
         "libp2p-crypto": {
@@ -3702,19 +3661,18 @@
           "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
           "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
           "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.1.1",
-            "bs58": "^4.0.1",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.7",
-            "node-forge": "^0.7.1",
-            "pem-jwk": "^1.5.1",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+            "asn1.js": "5.0.1",
+            "async": "2.6.1",
+            "browserify-aes": "1.2.0",
+            "bs58": "4.0.1",
+            "keypair": "1.0.1",
+            "libp2p-crypto-secp256k1": "0.2.2",
+            "multihashing-async": "0.4.8",
+            "node-forge": "0.7.5",
+            "pem-jwk": "1.5.1",
+            "protons": "1.0.1",
+            "rsa-pem-to-jwk": "1.1.3",
+            "tweetnacl": "1.0.0"
           }
         },
         "multihashing-async": {
@@ -3722,12 +3680,12 @@
           "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
           "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
           "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
+            "async": "2.6.1",
+            "blakejs": "1.1.0",
+            "js-sha3": "0.7.0",
+            "multihashes": "0.4.13",
+            "murmurhash3js": "3.0.1",
+            "nodeify": "1.0.1"
           }
         },
         "peer-id": {
@@ -3735,10 +3693,10 @@
           "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
           "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
           "requires": {
-            "async": "^2.6.0",
-            "libp2p-crypto": "~0.12.1",
-            "lodash": "^4.17.5",
-            "multihashes": "~0.4.13"
+            "async": "2.6.1",
+            "libp2p-crypto": "0.12.1",
+            "lodash": "4.17.10",
+            "multihashes": "0.4.13"
           }
         }
       }
@@ -3748,25 +3706,25 @@
       "resolved": "https://registry.npmjs.org/libp2p-kad-dht/-/libp2p-kad-dht-0.10.1.tgz",
       "integrity": "sha512-1Ao1Xns75cBd1nIQ2cIEVrg5mEne07x1aAosuXnklqy5arYYPghe5AqdcheGJ2Dm+mWABbULwpClTs/QjV3o0w==",
       "requires": {
-        "async": "^2.6.1",
-        "base32.js": "~0.1.0",
-        "cids": "~0.5.3",
-        "debug": "^3.1.0",
-        "hashlru": "^2.2.1",
-        "heap": "~0.2.6",
-        "interface-datastore": "~0.4.2",
-        "k-bucket": "^4.0.1",
-        "libp2p-crypto": "~0.13.0",
-        "libp2p-record": "~0.5.1",
-        "multihashing-async": "~0.5.1",
-        "peer-id": "~0.11.0",
-        "peer-info": "~0.14.1",
-        "priorityqueue": "~0.2.1",
-        "protons": "^1.0.1",
-        "pull-length-prefixed": "^1.3.1",
-        "pull-stream": "^3.6.8",
-        "varint": "^5.0.0",
-        "xor-distance": "^1.0.0"
+        "async": "2.6.1",
+        "base32.js": "0.1.0",
+        "cids": "0.5.3",
+        "debug": "3.1.0",
+        "hashlru": "2.2.1",
+        "heap": "0.2.6",
+        "interface-datastore": "0.4.2",
+        "k-bucket": "4.0.1",
+        "libp2p-crypto": "0.13.0",
+        "libp2p-record": "0.5.1",
+        "multihashing-async": "0.5.1",
+        "peer-id": "0.11.0",
+        "peer-info": "0.14.1",
+        "priorityqueue": "0.2.1",
+        "protons": "1.0.1",
+        "pull-length-prefixed": "1.3.1",
+        "pull-stream": "3.6.8",
+        "varint": "5.0.0",
+        "xor-distance": "1.0.0"
       }
     },
     "libp2p-keychain": {
@@ -3774,12 +3732,12 @@
       "resolved": "https://registry.npmjs.org/libp2p-keychain/-/libp2p-keychain-0.3.1.tgz",
       "integrity": "sha512-dsKw+gP/P7wDPkDpQZVVU+mRUlPqEmcYxGhvrEyjd7+UdcTxydEFbwvP0HQLVkkoLjsr2dVSauh7FdX7ZUmnQQ==",
       "requires": {
-        "async": "^2.6.0",
-        "deepmerge": "^1.5.2",
-        "interface-datastore": "~0.4.2",
-        "libp2p-crypto": "~0.12.0",
-        "pull-stream": "^3.6.1",
-        "sanitize-filename": "^1.6.1"
+        "async": "2.6.1",
+        "deepmerge": "1.5.2",
+        "interface-datastore": "0.4.2",
+        "libp2p-crypto": "0.12.1",
+        "pull-stream": "3.6.8",
+        "sanitize-filename": "1.6.1"
       },
       "dependencies": {
         "libp2p-crypto": {
@@ -3787,19 +3745,18 @@
           "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
           "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
           "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.1.1",
-            "bs58": "^4.0.1",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.7",
-            "node-forge": "^0.7.1",
-            "pem-jwk": "^1.5.1",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+            "asn1.js": "5.0.1",
+            "async": "2.6.1",
+            "browserify-aes": "1.2.0",
+            "bs58": "4.0.1",
+            "keypair": "1.0.1",
+            "libp2p-crypto-secp256k1": "0.2.2",
+            "multihashing-async": "0.4.8",
+            "node-forge": "0.7.5",
+            "pem-jwk": "1.5.1",
+            "protons": "1.0.1",
+            "rsa-pem-to-jwk": "1.1.3",
+            "tweetnacl": "1.0.0"
           }
         },
         "multihashing-async": {
@@ -3807,12 +3764,12 @@
           "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
           "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
           "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
+            "async": "2.6.1",
+            "blakejs": "1.1.0",
+            "js-sha3": "0.7.0",
+            "multihashes": "0.4.13",
+            "murmurhash3js": "3.0.1",
+            "nodeify": "1.0.1"
           }
         }
       }
@@ -3822,11 +3779,11 @@
       "resolved": "https://registry.npmjs.org/libp2p-mdns/-/libp2p-mdns-0.12.0.tgz",
       "integrity": "sha512-2K1IT8ZwnzS00Ws6MiLW89W2KAG+8NsrMez2laVZJtD9RpWBgc9+KGQ7KU1nYRyYXD/NGXNEiQ6HTkhSQvYbiQ==",
       "requires": {
-        "libp2p-tcp": "~0.12.0",
-        "multiaddr": "^5.0.0",
-        "multicast-dns": "^7.0.0",
-        "peer-id": "~0.10.7",
-        "peer-info": "~0.14.1"
+        "libp2p-tcp": "0.12.0",
+        "multiaddr": "5.0.0",
+        "multicast-dns": "7.0.0",
+        "peer-id": "0.10.7",
+        "peer-info": "0.14.1"
       },
       "dependencies": {
         "libp2p-crypto": {
@@ -3834,19 +3791,18 @@
           "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
           "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
           "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.1.1",
-            "bs58": "^4.0.1",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.7",
-            "node-forge": "^0.7.1",
-            "pem-jwk": "^1.5.1",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+            "asn1.js": "5.0.1",
+            "async": "2.6.1",
+            "browserify-aes": "1.2.0",
+            "bs58": "4.0.1",
+            "keypair": "1.0.1",
+            "libp2p-crypto-secp256k1": "0.2.2",
+            "multihashing-async": "0.4.8",
+            "node-forge": "0.7.5",
+            "pem-jwk": "1.5.1",
+            "protons": "1.0.1",
+            "rsa-pem-to-jwk": "1.1.3",
+            "tweetnacl": "1.0.0"
           }
         },
         "multihashing-async": {
@@ -3854,12 +3810,12 @@
           "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
           "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
           "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
+            "async": "2.6.1",
+            "blakejs": "1.1.0",
+            "js-sha3": "0.7.0",
+            "multihashes": "0.4.13",
+            "murmurhash3js": "3.0.1",
+            "nodeify": "1.0.1"
           }
         },
         "peer-id": {
@@ -3867,10 +3823,10 @@
           "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
           "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
           "requires": {
-            "async": "^2.6.0",
-            "libp2p-crypto": "~0.12.1",
-            "lodash": "^4.17.5",
-            "multihashes": "~0.4.13"
+            "async": "2.6.1",
+            "libp2p-crypto": "0.12.1",
+            "lodash": "4.17.10",
+            "multihashes": "0.4.13"
           }
         }
       }
@@ -3880,20 +3836,20 @@
       "resolved": "https://registry.npmjs.org/libp2p-mplex/-/libp2p-mplex-0.8.0.tgz",
       "integrity": "sha512-bjpHYqyxYNsnyKRgeATVU8u1wnP1vV/rEL+TOuVCv9WBnUPBifL9e+ggbEQtIQfZDsiDl3l43i8MJDuRKOag7A==",
       "requires": {
-        "async": "^2.6.1",
+        "async": "2.6.1",
         "chunky": "0.0.0",
-        "concat-stream": "^1.6.2",
-        "debug": "^3.1.0",
-        "duplexify": "^3.6.0",
-        "interface-connection": "~0.3.2",
-        "pull-catch": "^1.0.0",
-        "pull-stream": "^3.6.8",
-        "pull-stream-to-stream": "^1.3.4",
-        "pump": "^3.0.0",
-        "readable-stream": "^2.3.6",
-        "stream-to-pull-stream": "^1.7.2",
-        "through2": "^2.0.3",
-        "varint": "^5.0.0"
+        "concat-stream": "1.6.2",
+        "debug": "3.1.0",
+        "duplexify": "3.6.0",
+        "interface-connection": "0.3.2",
+        "pull-catch": "1.0.0",
+        "pull-stream": "3.6.8",
+        "pull-stream-to-stream": "1.3.4",
+        "pump": "3.0.0",
+        "readable-stream": "2.3.6",
+        "stream-to-pull-stream": "1.7.2",
+        "through2": "2.0.3",
+        "varint": "5.0.0"
       }
     },
     "libp2p-ping": {
@@ -3901,9 +3857,9 @@
       "resolved": "https://registry.npmjs.org/libp2p-ping/-/libp2p-ping-0.8.0.tgz",
       "integrity": "sha512-7GtCCvbs6sEabnjh2ZIdru8wuKP4Qux6alw7wuaMosqWkPeFnnFmQsGaWEGpwEmD49A1dsT+aIYvAx5jFB02Bw==",
       "requires": {
-        "libp2p-crypto": "~0.13.0",
-        "pull-handshake": "^1.1.4",
-        "pull-stream": "^3.6.7"
+        "libp2p-crypto": "0.13.0",
+        "pull-handshake": "1.1.4",
+        "pull-stream": "3.6.8"
       }
     },
     "libp2p-record": {
@@ -3911,13 +3867,13 @@
       "resolved": "https://registry.npmjs.org/libp2p-record/-/libp2p-record-0.5.1.tgz",
       "integrity": "sha512-e2qLv0Tx4yBrGQrTbogWKpRFAM5rhmwTAnm/IfVn8/TzRBcB4F0PTVRB/Wf0eFCa8dNmD6vTn9wyhe+zmcI1zQ==",
       "requires": {
-        "async": "^2.5.0",
-        "buffer-split": "^1.0.0",
-        "left-pad": "^1.1.3",
-        "multihashes": "~0.4.9",
-        "multihashing-async": "~0.4.6",
-        "peer-id": "~0.10.0",
-        "protons": "^1.0.0"
+        "async": "2.6.1",
+        "buffer-split": "1.0.0",
+        "left-pad": "1.3.0",
+        "multihashes": "0.4.13",
+        "multihashing-async": "0.4.8",
+        "peer-id": "0.10.7",
+        "protons": "1.0.1"
       },
       "dependencies": {
         "libp2p-crypto": {
@@ -3925,19 +3881,18 @@
           "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
           "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
           "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.1.1",
-            "bs58": "^4.0.1",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.7",
-            "node-forge": "^0.7.1",
-            "pem-jwk": "^1.5.1",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+            "asn1.js": "5.0.1",
+            "async": "2.6.1",
+            "browserify-aes": "1.2.0",
+            "bs58": "4.0.1",
+            "keypair": "1.0.1",
+            "libp2p-crypto-secp256k1": "0.2.2",
+            "multihashing-async": "0.4.8",
+            "node-forge": "0.7.5",
+            "pem-jwk": "1.5.1",
+            "protons": "1.0.1",
+            "rsa-pem-to-jwk": "1.1.3",
+            "tweetnacl": "1.0.0"
           }
         },
         "multihashing-async": {
@@ -3945,12 +3900,12 @@
           "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
           "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
           "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
+            "async": "2.6.1",
+            "blakejs": "1.1.0",
+            "js-sha3": "0.7.0",
+            "multihashes": "0.4.13",
+            "murmurhash3js": "3.0.1",
+            "nodeify": "1.0.1"
           }
         },
         "peer-id": {
@@ -3958,10 +3913,10 @@
           "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
           "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
           "requires": {
-            "async": "^2.6.0",
-            "libp2p-crypto": "~0.12.1",
-            "lodash": "^4.17.5",
-            "multihashes": "~0.4.13"
+            "async": "2.6.1",
+            "libp2p-crypto": "0.12.1",
+            "lodash": "4.17.10",
+            "multihashes": "0.4.13"
           }
         }
       }
@@ -3971,18 +3926,18 @@
       "resolved": "https://registry.npmjs.org/libp2p-secio/-/libp2p-secio-0.10.0.tgz",
       "integrity": "sha512-/0nirr4UBdQBbETBliGYD6mLzKl+ZUX+2Kzmpk98Pdjdam5W2IhLF8zSeeK6Z4d/gJOaLdf2H8C6wLrwOSil8A==",
       "requires": {
-        "async": "^2.6.0",
-        "debug": "^3.1.0",
-        "interface-connection": "~0.3.2",
-        "libp2p-crypto": "~0.12.1",
-        "multihashing-async": "~0.4.8",
-        "peer-id": "~0.10.7",
-        "peer-info": "^0.14.0",
-        "protons": "^1.0.1",
-        "pull-defer": "^0.2.2",
-        "pull-handshake": "^1.1.4",
-        "pull-length-prefixed": "^1.3.0",
-        "pull-stream": "^3.6.7"
+        "async": "2.6.1",
+        "debug": "3.1.0",
+        "interface-connection": "0.3.2",
+        "libp2p-crypto": "0.12.1",
+        "multihashing-async": "0.4.8",
+        "peer-id": "0.10.7",
+        "peer-info": "0.14.1",
+        "protons": "1.0.1",
+        "pull-defer": "0.2.2",
+        "pull-handshake": "1.1.4",
+        "pull-length-prefixed": "1.3.1",
+        "pull-stream": "3.6.8"
       },
       "dependencies": {
         "libp2p-crypto": {
@@ -3990,19 +3945,18 @@
           "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
           "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
           "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.1.1",
-            "bs58": "^4.0.1",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.7",
-            "node-forge": "^0.7.1",
-            "pem-jwk": "^1.5.1",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+            "asn1.js": "5.0.1",
+            "async": "2.6.1",
+            "browserify-aes": "1.2.0",
+            "bs58": "4.0.1",
+            "keypair": "1.0.1",
+            "libp2p-crypto-secp256k1": "0.2.2",
+            "multihashing-async": "0.4.8",
+            "node-forge": "0.7.5",
+            "pem-jwk": "1.5.1",
+            "protons": "1.0.1",
+            "rsa-pem-to-jwk": "1.1.3",
+            "tweetnacl": "1.0.0"
           }
         },
         "multihashing-async": {
@@ -4010,12 +3964,12 @@
           "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
           "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
           "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
+            "async": "2.6.1",
+            "blakejs": "1.1.0",
+            "js-sha3": "0.7.0",
+            "multihashes": "0.4.13",
+            "murmurhash3js": "3.0.1",
+            "nodeify": "1.0.1"
           }
         },
         "peer-id": {
@@ -4023,10 +3977,10 @@
           "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
           "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
           "requires": {
-            "async": "^2.6.0",
-            "libp2p-crypto": "~0.12.1",
-            "lodash": "^4.17.5",
-            "multihashes": "~0.4.13"
+            "async": "2.6.1",
+            "libp2p-crypto": "0.12.1",
+            "lodash": "4.17.10",
+            "multihashes": "0.4.13"
           }
         }
       }
@@ -4036,22 +3990,22 @@
       "resolved": "https://registry.npmjs.org/libp2p-switch/-/libp2p-switch-0.40.6.tgz",
       "integrity": "sha512-2nnvaH8o1Mn7lBkR/p9eB6brRPRd4g/pbm9eRrSwdK0J5Dq8f6ps3u6NYm4DuftfEiWbJOrsm0EwAa/lC34FPg==",
       "requires": {
-        "async": "^2.6.0",
-        "big.js": "^5.1.2",
-        "debug": "^3.1.0",
-        "hashlru": "^2.2.1",
-        "interface-connection": "~0.3.2",
-        "ip-address": "^5.8.9",
-        "libp2p-circuit": "~0.2.0",
-        "libp2p-identify": "~0.7.1",
-        "lodash.includes": "^4.3.0",
-        "moving-average": "^1.0.0",
-        "multiaddr": "^5.0.0",
-        "multistream-select": "~0.14.2",
-        "once": "^1.4.0",
-        "peer-id": "~0.10.7",
-        "peer-info": "~0.14.1",
-        "pull-stream": "^3.6.7"
+        "async": "2.6.1",
+        "big.js": "5.1.2",
+        "debug": "3.1.0",
+        "hashlru": "2.2.1",
+        "interface-connection": "0.3.2",
+        "ip-address": "5.8.9",
+        "libp2p-circuit": "0.2.0",
+        "libp2p-identify": "0.7.1",
+        "lodash.includes": "4.3.0",
+        "moving-average": "1.0.0",
+        "multiaddr": "5.0.0",
+        "multistream-select": "0.14.2",
+        "once": "1.4.0",
+        "peer-id": "0.10.7",
+        "peer-info": "0.14.1",
+        "pull-stream": "3.6.8"
       },
       "dependencies": {
         "libp2p-crypto": {
@@ -4059,19 +4013,18 @@
           "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
           "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
           "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.1.1",
-            "bs58": "^4.0.1",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.7",
-            "node-forge": "^0.7.1",
-            "pem-jwk": "^1.5.1",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+            "asn1.js": "5.0.1",
+            "async": "2.6.1",
+            "browserify-aes": "1.2.0",
+            "bs58": "4.0.1",
+            "keypair": "1.0.1",
+            "libp2p-crypto-secp256k1": "0.2.2",
+            "multihashing-async": "0.4.8",
+            "node-forge": "0.7.5",
+            "pem-jwk": "1.5.1",
+            "protons": "1.0.1",
+            "rsa-pem-to-jwk": "1.1.3",
+            "tweetnacl": "1.0.0"
           }
         },
         "multihashing-async": {
@@ -4079,12 +4032,12 @@
           "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
           "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
           "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
+            "async": "2.6.1",
+            "blakejs": "1.1.0",
+            "js-sha3": "0.7.0",
+            "multihashes": "0.4.13",
+            "murmurhash3js": "3.0.1",
+            "nodeify": "1.0.1"
           }
         },
         "peer-id": {
@@ -4092,10 +4045,10 @@
           "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
           "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
           "requires": {
-            "async": "^2.6.0",
-            "libp2p-crypto": "~0.12.1",
-            "lodash": "^4.17.5",
-            "multihashes": "~0.4.13"
+            "async": "2.6.1",
+            "libp2p-crypto": "0.12.1",
+            "lodash": "4.17.10",
+            "multihashes": "0.4.13"
           }
         }
       }
@@ -4105,16 +4058,16 @@
       "resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.12.0.tgz",
       "integrity": "sha512-zuq8bpnra1XGUK6DcsiDT0fY2QWoJQBmdQgx6Hz4L2IJTPmGBN3ww3Z8VhSqNaPmm/Dcfs7pug+pamIu3olmuQ==",
       "requires": {
-        "class-is": "^1.1.0",
-        "debug": "^3.1.0",
-        "interface-connection": "~0.3.2",
-        "ip-address": "^5.8.9",
-        "lodash.includes": "^4.3.0",
-        "lodash.isfunction": "^3.0.9",
-        "mafmt": "^6.0.0",
-        "multiaddr": "^4.0.0",
-        "once": "^1.4.0",
-        "stream-to-pull-stream": "^1.7.2"
+        "class-is": "1.1.0",
+        "debug": "3.1.0",
+        "interface-connection": "0.3.2",
+        "ip-address": "5.8.9",
+        "lodash.includes": "4.3.0",
+        "lodash.isfunction": "3.0.9",
+        "mafmt": "6.0.0",
+        "multiaddr": "4.0.0",
+        "once": "1.4.0",
+        "stream-to-pull-stream": "1.7.2"
       },
       "dependencies": {
         "multiaddr": {
@@ -4122,14 +4075,14 @@
           "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-4.0.0.tgz",
           "integrity": "sha512-zUatrOCfBd/tJNOSoJ10d2EI2FDXB9PyPZhqUMdXE9mOyR3C+HLuOjga2Ga/eChwvEHIpTYRMoIKF2Nv7af2qQ==",
           "requires": {
-            "bs58": "^4.0.1",
-            "class-is": "^1.1.0",
-            "ip": "^1.1.5",
-            "ip-address": "^5.8.9",
-            "lodash.filter": "^4.6.0",
-            "lodash.map": "^4.6.0",
-            "varint": "^5.0.0",
-            "xtend": "^4.0.1"
+            "bs58": "4.0.1",
+            "class-is": "1.1.0",
+            "ip": "1.1.5",
+            "ip-address": "5.8.9",
+            "lodash.filter": "4.6.0",
+            "lodash.map": "4.6.0",
+            "varint": "5.0.0",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -4139,26 +4092,25 @@
       "resolved": "https://registry.npmjs.org/libp2p-webrtc-star/-/libp2p-webrtc-star-0.15.3.tgz",
       "integrity": "sha512-bt6d9Oxd7/fF8zHybM4xVJKV2tl7+08kyRw+R5YkNbX5lrYT7f0NKWJUBrOrw4BnsIdEn32bDPR/yQNinKm0Vg==",
       "requires": {
-        "async": "^2.6.1",
-        "class-is": "^1.1.0",
-        "debug": "^3.1.0",
-        "detect-node": "^2.0.3",
-        "epimetheus": "^1.0.55",
-        "hapi": "^16.6.2",
-        "inert": "^4.2.1",
-        "interface-connection": "~0.3.2",
-        "mafmt": "^6.0.0",
-        "minimist": "^1.2.0",
-        "multiaddr": "^5.0.0",
-        "once": "^1.4.0",
-        "peer-id": "~0.10.7",
-        "peer-info": "~0.14.1",
-        "pull-stream": "^3.6.8",
-        "simple-peer": "^9.1.2",
-        "socket.io": "^2.1.1",
-        "socket.io-client": "^2.1.1",
-        "stream-to-pull-stream": "^1.7.2",
-        "webrtcsupport": "github:ipfs/webrtcsupport#0669f576582c53a3a42aa5ac014fcc5966809615"
+        "async": "2.6.1",
+        "class-is": "1.1.0",
+        "debug": "3.1.0",
+        "detect-node": "2.0.3",
+        "epimetheus": "1.0.55",
+        "hapi": "16.6.3",
+        "inert": "4.2.1",
+        "interface-connection": "0.3.2",
+        "mafmt": "6.0.0",
+        "minimist": "1.2.0",
+        "multiaddr": "5.0.0",
+        "once": "1.4.0",
+        "peer-id": "0.10.7",
+        "peer-info": "0.14.1",
+        "pull-stream": "3.6.8",
+        "simple-peer": "9.1.2",
+        "socket.io": "2.1.1",
+        "socket.io-client": "2.1.1",
+        "stream-to-pull-stream": "1.7.2"
       },
       "dependencies": {
         "libp2p-crypto": {
@@ -4166,19 +4118,18 @@
           "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
           "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
           "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.1.1",
-            "bs58": "^4.0.1",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.7",
-            "node-forge": "^0.7.1",
-            "pem-jwk": "^1.5.1",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+            "asn1.js": "5.0.1",
+            "async": "2.6.1",
+            "browserify-aes": "1.2.0",
+            "bs58": "4.0.1",
+            "keypair": "1.0.1",
+            "libp2p-crypto-secp256k1": "0.2.2",
+            "multihashing-async": "0.4.8",
+            "node-forge": "0.7.5",
+            "pem-jwk": "1.5.1",
+            "protons": "1.0.1",
+            "rsa-pem-to-jwk": "1.1.3",
+            "tweetnacl": "1.0.0"
           }
         },
         "multihashing-async": {
@@ -4186,12 +4137,12 @@
           "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
           "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
           "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
+            "async": "2.6.1",
+            "blakejs": "1.1.0",
+            "js-sha3": "0.7.0",
+            "multihashes": "0.4.13",
+            "murmurhash3js": "3.0.1",
+            "nodeify": "1.0.1"
           }
         },
         "peer-id": {
@@ -4199,10 +4150,10 @@
           "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
           "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
           "requires": {
-            "async": "^2.6.0",
-            "libp2p-crypto": "~0.12.1",
-            "lodash": "^4.17.5",
-            "multihashes": "~0.4.13"
+            "async": "2.6.1",
+            "libp2p-crypto": "0.12.1",
+            "lodash": "4.17.10",
+            "multihashes": "0.4.13"
           }
         }
       }
@@ -4212,22 +4163,22 @@
       "resolved": "https://registry.npmjs.org/libp2p-websocket-star/-/libp2p-websocket-star-0.8.1.tgz",
       "integrity": "sha512-lDzL9fGWXveu6HEc6xuIEi036Bg1IQ+PliJJHxgSS9ozTkUwMT5dfvyugSWsZ7Gh4q7BYzr5cDZCNkR42GcRZw==",
       "requires": {
-        "async": "^2.6.1",
-        "class-is": "^1.1.0",
+        "async": "2.6.1",
+        "class-is": "1.1.0",
         "data-queue": "0.0.3",
-        "debug": "^3.1.0",
-        "interface-connection": "~0.3.2",
-        "libp2p-crypto": "~0.13.0",
-        "mafmt": "^6.0.0",
+        "debug": "3.1.0",
+        "interface-connection": "0.3.2",
+        "libp2p-crypto": "0.13.0",
+        "mafmt": "6.0.0",
         "merge-recursive": "0.0.3",
-        "multiaddr": "^5.0.0",
-        "once": "^1.4.0",
-        "peer-id": "~0.10.7",
-        "peer-info": "~0.14.1",
-        "pull-stream": "^3.6.8",
-        "socket.io-client": "^2.1.1",
-        "socket.io-pull-stream": "~0.1.5",
-        "uuid": "^3.2.1"
+        "multiaddr": "5.0.0",
+        "once": "1.4.0",
+        "peer-id": "0.10.7",
+        "peer-info": "0.14.1",
+        "pull-stream": "3.6.8",
+        "socket.io-client": "2.1.1",
+        "socket.io-pull-stream": "0.1.5",
+        "uuid": "3.3.2"
       },
       "dependencies": {
         "multihashing-async": {
@@ -4235,12 +4186,12 @@
           "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
           "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
           "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
+            "async": "2.6.1",
+            "blakejs": "1.1.0",
+            "js-sha3": "0.7.0",
+            "multihashes": "0.4.13",
+            "murmurhash3js": "3.0.1",
+            "nodeify": "1.0.1"
           }
         },
         "peer-id": {
@@ -4248,10 +4199,10 @@
           "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
           "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
           "requires": {
-            "async": "^2.6.0",
-            "libp2p-crypto": "~0.12.1",
-            "lodash": "^4.17.5",
-            "multihashes": "~0.4.13"
+            "async": "2.6.1",
+            "libp2p-crypto": "0.12.1",
+            "lodash": "4.17.10",
+            "multihashes": "0.4.13"
           },
           "dependencies": {
             "libp2p-crypto": {
@@ -4259,19 +4210,18 @@
               "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
               "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
               "requires": {
-                "asn1.js": "^5.0.0",
-                "async": "^2.6.0",
-                "browserify-aes": "^1.1.1",
-                "bs58": "^4.0.1",
-                "keypair": "^1.0.1",
-                "libp2p-crypto-secp256k1": "~0.2.2",
-                "multihashing-async": "~0.4.7",
-                "node-forge": "^0.7.1",
-                "pem-jwk": "^1.5.1",
-                "protons": "^1.0.1",
-                "rsa-pem-to-jwk": "^1.1.3",
-                "tweetnacl": "^1.0.0",
-                "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+                "asn1.js": "5.0.1",
+                "async": "2.6.1",
+                "browserify-aes": "1.2.0",
+                "bs58": "4.0.1",
+                "keypair": "1.0.1",
+                "libp2p-crypto-secp256k1": "0.2.2",
+                "multihashing-async": "0.4.8",
+                "node-forge": "0.7.5",
+                "pem-jwk": "1.5.1",
+                "protons": "1.0.1",
+                "rsa-pem-to-jwk": "1.1.3",
+                "tweetnacl": "1.0.0"
               }
             }
           }
@@ -4283,11 +4233,11 @@
       "resolved": "https://registry.npmjs.org/libp2p-websockets/-/libp2p-websockets-0.12.0.tgz",
       "integrity": "sha512-I4m0MNqzBOwoIneCF/5mXHGaavNf0Hoe/7NFg2WUm74o7240dZEIuNkAoLu1+OJyOPyu4RXeIBhUOS4cjBdCew==",
       "requires": {
-        "class-is": "^1.1.0",
-        "interface-connection": "~0.3.2",
-        "lodash.includes": "^4.3.0",
-        "mafmt": "^6.0.0",
-        "pull-ws": "^3.3.1"
+        "class-is": "1.1.0",
+        "interface-connection": "0.3.2",
+        "lodash.includes": "4.3.0",
+        "mafmt": "6.0.0",
+        "pull-ws": "3.3.1"
       }
     },
     "load-json-file": {
@@ -4295,10 +4245,10 @@
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
       "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^4.0.0",
-        "pify": "^3.0.0",
-        "strip-bom": "^3.0.0"
+        "graceful-fs": "4.1.11",
+        "parse-json": "4.0.0",
+        "pify": "3.0.0",
+        "strip-bom": "3.0.0"
       }
     },
     "locate-path": {
@@ -4306,8 +4256,8 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
       "requires": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "3.0.0",
+        "path-exists": "3.0.0"
       }
     },
     "lock-me": {
@@ -4315,11 +4265,10 @@
       "resolved": "https://registry.npmjs.org/lock-me/-/lock-me-1.0.4.tgz",
       "integrity": "sha512-PH/uZMCtlTfiPcKnNVc8cF57Jrc9uTcil4qL6f1faTWV71J3ym8LIlaO385BtoC3MQb+jt3t2R8SnHxcQ5pafw==",
       "requires": {
-        "async": "^2.1.5",
-        "find-process": "^1.0.5",
-        "fs-ext": "github:baudehlo/node-fs-ext#7c9824f3dc330e795aa13359d96252860bd3a684",
-        "nodeify": "^1.0.1",
-        "once": "^1.4.0"
+        "async": "2.6.1",
+        "find-process": "1.1.1",
+        "nodeify": "1.0.1",
+        "once": "1.4.0"
       }
     },
     "lodash": {
@@ -4467,8 +4416,8 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
       "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
       }
     },
     "ltgt": {
@@ -4481,7 +4430,7 @@
       "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-6.0.0.tgz",
       "integrity": "sha512-ikjvRXcbEu/kpSQSUlCX5mj2sRZs18rjFAR3azO7mTJ1HPtTcd1XL5y/ey5wSuRjX4dsgGIPEc9VYF3dUaudPw==",
       "requires": {
-        "multiaddr": "^4.0.0"
+        "multiaddr": "4.0.0"
       },
       "dependencies": {
         "multiaddr": {
@@ -4489,14 +4438,14 @@
           "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-4.0.0.tgz",
           "integrity": "sha512-zUatrOCfBd/tJNOSoJ10d2EI2FDXB9PyPZhqUMdXE9mOyR3C+HLuOjga2Ga/eChwvEHIpTYRMoIKF2Nv7af2qQ==",
           "requires": {
-            "bs58": "^4.0.1",
-            "class-is": "^1.1.0",
-            "ip": "^1.1.5",
-            "ip-address": "^5.8.9",
-            "lodash.filter": "^4.6.0",
-            "lodash.map": "^4.6.0",
-            "varint": "^5.0.0",
-            "xtend": "^4.0.1"
+            "bs58": "4.0.1",
+            "class-is": "1.1.0",
+            "ip": "1.1.5",
+            "ip-address": "5.8.9",
+            "lodash.filter": "4.6.0",
+            "lodash.map": "4.6.0",
+            "varint": "5.0.0",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -4506,7 +4455,7 @@
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "requires": {
-        "pify": "^3.0.0"
+        "pify": "3.0.0"
       }
     },
     "md5.js": {
@@ -4514,8 +4463,8 @@
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
       "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
+        "hash-base": "3.0.4",
+        "inherits": "2.0.3"
       }
     },
     "mem": {
@@ -4523,7 +4472,7 @@
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "memdown": {
@@ -4531,12 +4480,12 @@
       "resolved": "https://registry.npmjs.org/memdown/-/memdown-3.0.0.tgz",
       "integrity": "sha512-tbV02LfZMWLcHcq4tw++NuqMO+FZX8tNJEiD2aNRm48ZZusVg5N8NART+dmBkepJVye986oixErf7jfXboMGMA==",
       "requires": {
-        "abstract-leveldown": "~5.0.0",
-        "functional-red-black-tree": "~1.0.1",
-        "immediate": "~3.2.3",
-        "inherits": "~2.0.1",
-        "ltgt": "~2.2.0",
-        "safe-buffer": "~5.1.1"
+        "abstract-leveldown": "5.0.0",
+        "functional-red-black-tree": "1.0.1",
+        "immediate": "3.2.3",
+        "inherits": "2.0.3",
+        "ltgt": "2.2.1",
+        "safe-buffer": "5.1.2"
       }
     },
     "merge-recursive": {
@@ -4554,14 +4503,14 @@
       "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.1.tgz",
       "integrity": "sha512-Qp9Mpb3xazznXzzGQBqHbqCpT2AR9joUOHYYPiQjYCarrdCPCnLWXo4BFv77y4xN26KR224xoU1n/qYY7RYYgw==",
       "requires": {
-        "async": "^1.4.2",
-        "ethereumjs-util": "^5.0.0",
+        "async": "1.5.2",
+        "ethereumjs-util": "5.2.0",
         "level-ws": "0.0.0",
-        "levelup": "^1.2.1",
-        "memdown": "^1.0.0",
-        "readable-stream": "^2.0.0",
-        "rlp": "^2.0.0",
-        "semaphore": ">=1.0.1"
+        "levelup": "1.3.9",
+        "memdown": "1.4.1",
+        "readable-stream": "2.3.6",
+        "rlp": "2.1.0",
+        "semaphore": "1.1.0"
       },
       "dependencies": {
         "abstract-leveldown": {
@@ -4569,7 +4518,7 @@
           "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
           "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
           "requires": {
-            "xtend": "~4.0.0"
+            "xtend": "4.0.1"
           }
         },
         "async": {
@@ -4582,7 +4531,7 @@
           "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
           "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
           "requires": {
-            "abstract-leveldown": "~2.6.0"
+            "abstract-leveldown": "2.6.3"
           }
         },
         "isarray": {
@@ -4600,7 +4549,7 @@
           "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
           "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
           "requires": {
-            "errno": "~0.1.1"
+            "errno": "0.1.7"
           }
         },
         "level-iterator-stream": {
@@ -4608,10 +4557,10 @@
           "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
           "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
           "requires": {
-            "inherits": "^2.0.1",
-            "level-errors": "^1.0.3",
-            "readable-stream": "^1.0.33",
-            "xtend": "^4.0.0"
+            "inherits": "2.0.3",
+            "level-errors": "1.0.5",
+            "readable-stream": "1.1.14",
+            "xtend": "4.0.1"
           },
           "dependencies": {
             "readable-stream": {
@@ -4619,10 +4568,10 @@
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
               "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
                 "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
+                "string_decoder": "0.10.31"
               }
             }
           }
@@ -4632,13 +4581,13 @@
           "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
           "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
           "requires": {
-            "deferred-leveldown": "~1.2.1",
-            "level-codec": "~7.0.0",
-            "level-errors": "~1.0.3",
-            "level-iterator-stream": "~1.3.0",
-            "prr": "~1.0.1",
-            "semver": "~5.4.1",
-            "xtend": "~4.0.0"
+            "deferred-leveldown": "1.2.2",
+            "level-codec": "7.0.1",
+            "level-errors": "1.0.5",
+            "level-iterator-stream": "1.3.1",
+            "prr": "1.0.1",
+            "semver": "5.4.1",
+            "xtend": "4.0.1"
           }
         },
         "memdown": {
@@ -4646,12 +4595,12 @@
           "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
           "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
           "requires": {
-            "abstract-leveldown": "~2.7.1",
-            "functional-red-black-tree": "^1.0.1",
-            "immediate": "^3.2.3",
-            "inherits": "~2.0.1",
-            "ltgt": "~2.2.0",
-            "safe-buffer": "~5.1.1"
+            "abstract-leveldown": "2.7.2",
+            "functional-red-black-tree": "1.0.1",
+            "immediate": "3.2.3",
+            "inherits": "2.0.3",
+            "ltgt": "2.2.1",
+            "safe-buffer": "5.1.2"
           },
           "dependencies": {
             "abstract-leveldown": {
@@ -4659,7 +4608,7 @@
               "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
               "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
               "requires": {
-                "xtend": "~4.0.0"
+                "xtend": "4.0.1"
               }
             }
           }
@@ -4691,7 +4640,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
       "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
       "requires": {
-        "mime-db": "~1.35.0"
+        "mime-db": "1.35.0"
       }
     },
     "mimic-fn": {
@@ -4709,8 +4658,8 @@
       "resolved": "https://registry.npmjs.org/mimos/-/mimos-3.0.3.tgz",
       "integrity": "sha1-uRCQcq03jCty9qAQHEPd+ys2ZB8=",
       "requires": {
-        "hoek": "4.x.x",
-        "mime-db": "1.x.x"
+        "hoek": "4.2.1",
+        "mime-db": "1.35.0"
       },
       "dependencies": {
         "hoek": {
@@ -4735,7 +4684,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -4794,7 +4743,7 @@
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^2.0.0"
+            "has-flag": "2.0.0"
           }
         }
       }
@@ -4804,10 +4753,10 @@
       "resolved": "https://registry.npmjs.org/mortice/-/mortice-1.2.1.tgz",
       "integrity": "sha512-O9O2Cx6u/AcPLLELYbCGZkcg2yvPo7zJk3+v7h8Emlne5+sg48W/shwtG5UAD+2UIuMMayC+fJ/OlZXwHfA08g==",
       "requires": {
-        "observable-webworkers": "^1.0.0",
-        "p-queue": "^2.4.2",
-        "promise-timeout": "^1.3.0",
-        "shortid": "^2.2.8"
+        "observable-webworkers": "1.0.0",
+        "p-queue": "2.4.2",
+        "promise-timeout": "1.3.0",
+        "shortid": "2.2.12"
       }
     },
     "moving-average": {
@@ -4825,14 +4774,14 @@
       "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-5.0.0.tgz",
       "integrity": "sha512-IMEo+iCv53MT8c/6SQWbJpJUEENTYr6qp7o635BKJLQG2nkxOIO9LSEFhF5e56Az+DkmI6HGAAjp69AT7Sjulw==",
       "requires": {
-        "bs58": "^4.0.1",
-        "class-is": "^1.1.0",
-        "ip": "^1.1.5",
-        "ip-address": "^5.8.9",
-        "lodash.filter": "^4.6.0",
-        "lodash.map": "^4.6.0",
-        "varint": "^5.0.0",
-        "xtend": "^4.0.1"
+        "bs58": "4.0.1",
+        "class-is": "1.1.0",
+        "ip": "1.1.5",
+        "ip-address": "5.8.9",
+        "lodash.filter": "4.6.0",
+        "lodash.map": "4.6.0",
+        "varint": "5.0.0",
+        "xtend": "4.0.1"
       }
     },
     "multibase": {
@@ -4848,8 +4797,8 @@
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.0.0.tgz",
       "integrity": "sha512-BqB5TtIXHo+8gN33N1CA1clsvPsAJlnc6D49SzfQA0xq75cxj15g2y9NaRdf4x2u4v1P66PBC+Wg6YgPO5Bc/g==",
       "requires": {
-        "dns-packet": "^4.0.0",
-        "thunky": "^1.0.2"
+        "dns-packet": "4.2.0",
+        "thunky": "1.0.2"
       }
     },
     "multicodec": {
@@ -4857,7 +4806,7 @@
       "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.2.7.tgz",
       "integrity": "sha512-96xc9zs7bsclMW0Po9ERnRFqcsWHY8OZ8JW/I8DeHG58YYJZy3cBGI00Ze7hz9Ix56DNHMTSxEj9cgoZByruMg==",
       "requires": {
-        "varint": "^5.0.0"
+        "varint": "5.0.0"
       }
     },
     "multihashes": {
@@ -4865,8 +4814,8 @@
       "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.13.tgz",
       "integrity": "sha512-HwJGEKPCpLlNlgGQA56CYh/Wsqa+c4JAq8+mheIgw7OK5T4QvNJqgp6TH8gZ4q4l1aiWeNat/H/MrFXmTuoFfQ==",
       "requires": {
-        "bs58": "^4.0.1",
-        "varint": "^5.0.0"
+        "bs58": "4.0.1",
+        "varint": "5.0.0"
       }
     },
     "multihashing-async": {
@@ -4874,12 +4823,12 @@
       "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.5.1.tgz",
       "integrity": "sha512-Ft5lQNcJCfsns1QN1TDXqPZrrNwBYqIokprYJR2h2Jj01x0GFcYmJYAqHvme6vJoyI3XptEcmZpdr9g5Oy7q3Q==",
       "requires": {
-        "async": "^2.6.1",
-        "blakejs": "^1.1.0",
-        "js-sha3": "^0.7.0",
-        "multihashes": "~0.4.13",
-        "murmurhash3js": "^3.0.1",
-        "nodeify": "^1.0.1"
+        "async": "2.6.1",
+        "blakejs": "1.1.0",
+        "js-sha3": "0.7.0",
+        "multihashes": "0.4.13",
+        "murmurhash3js": "3.0.1",
+        "nodeify": "1.0.1"
       }
     },
     "multistream-select": {
@@ -4887,17 +4836,17 @@
       "resolved": "https://registry.npmjs.org/multistream-select/-/multistream-select-0.14.2.tgz",
       "integrity": "sha512-s+e2a6YAvImGejfAy/HAovuvSArSqLG+seSs8yMCOj76dPBh+h8vyQaWkhpfpeVRTzDnNTdvNkMrFjqp97kcXg==",
       "requires": {
-        "async": "^2.6.0",
-        "debug": "^3.1.0",
-        "interface-connection": "~0.3.2",
-        "lodash.isfunction": "^3.0.9",
-        "lodash.range": "^3.2.0",
-        "once": "^1.4.0",
-        "pull-handshake": "^1.1.4",
-        "pull-length-prefixed": "^1.3.0",
-        "pull-stream": "^3.6.7",
-        "semver": "^5.5.0",
-        "varint": "^5.0.0"
+        "async": "2.6.1",
+        "debug": "3.1.0",
+        "interface-connection": "0.3.2",
+        "lodash.isfunction": "3.0.9",
+        "lodash.range": "3.2.0",
+        "once": "1.4.0",
+        "pull-handshake": "1.1.4",
+        "pull-length-prefixed": "1.3.1",
+        "pull-stream": "3.6.8",
+        "semver": "5.5.0",
+        "varint": "5.0.0"
       }
     },
     "murmurhash3js": {
@@ -4920,10 +4869,10 @@
       "resolved": "https://registry.npmjs.org/ndjson/-/ndjson-1.5.0.tgz",
       "integrity": "sha1-rmA7NrE0vOw0e0UkIrC/mNWDLsg=",
       "requires": {
-        "json-stringify-safe": "^5.0.1",
-        "minimist": "^1.2.0",
-        "split2": "^2.1.0",
-        "through2": "^2.0.3"
+        "json-stringify-safe": "5.0.1",
+        "minimist": "1.2.0",
+        "split2": "2.2.0",
+        "through2": "2.0.3"
       }
     },
     "negotiator": {
@@ -4936,8 +4885,8 @@
       "resolved": "https://registry.npmjs.org/nigel/-/nigel-2.0.2.tgz",
       "integrity": "sha1-k6GGb7DFLYc5CqdeKxYfS1x15bE=",
       "requires": {
-        "hoek": "4.x.x",
-        "vise": "2.x.x"
+        "hoek": "4.2.1",
+        "vise": "2.0.2"
       },
       "dependencies": {
         "hoek": {
@@ -4952,7 +4901,7 @@
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.4.3.tgz",
       "integrity": "sha512-b656V5C0628gOOA2kwcpNA/bxdlqYF9FvxJ+qqVX0ctdXNVZpS8J6xEUYir3WAKc7U0BH/NRlSpNbGsy+azjeg==",
       "requires": {
-        "semver": "^5.4.1"
+        "semver": "5.5.0"
       }
     },
     "node-forge": {
@@ -4965,7 +4914,7 @@
       "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-1.3.1.tgz",
       "integrity": "sha512-NMWCSWWc6JbHT5PyWlNT2i8r7PgGYXVntmKawY83k/M0UJScZ5jirb61TLnqKwd815DfBQu+lR3sRw08SPzIaQ==",
       "requires": {
-        "write-file-atomic": "^1.1.4"
+        "write-file-atomic": "1.3.4"
       },
       "dependencies": {
         "write-file-atomic": {
@@ -4973,9 +4922,9 @@
           "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
           "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
           "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "slide": "^1.1.5"
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "slide": "1.1.6"
           }
         }
       }
@@ -4985,8 +4934,8 @@
       "resolved": "https://registry.npmjs.org/nodeify/-/nodeify-1.0.1.tgz",
       "integrity": "sha1-ZKtpp7268DzhB7TwM1yHwLnpGx0=",
       "requires": {
-        "is-promise": "~1.0.0",
-        "promise": "~1.3.0"
+        "is-promise": "1.0.1",
+        "promise": "1.3.0"
       }
     },
     "noop-logger": {
@@ -4999,10 +4948,10 @@
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.7.1",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.5.0",
+        "validate-npm-package-license": "3.0.3"
       }
     },
     "npm-run-path": {
@@ -5010,7 +4959,7 @@
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "requires": {
-        "path-key": "^2.0.0"
+        "path-key": "2.0.1"
       }
     },
     "npmlog": {
@@ -5018,10 +4967,10 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "requires": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
+        "are-we-there-yet": "1.1.5",
+        "console-control-strings": "1.1.0",
+        "gauge": "2.7.4",
+        "set-blocking": "2.0.0"
       }
     },
     "number-is-nan": {
@@ -5054,7 +5003,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "optimist": {
@@ -5062,7 +5011,7 @@
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
       "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
       "requires": {
-        "wordwrap": "~0.0.2"
+        "wordwrap": "0.0.3"
       }
     },
     "optional": {
@@ -5077,21 +5026,20 @@
       "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
     },
     "orbit-db": {
-      "version": "github:orbitdb/orbit-db#6a71a41ef59fe94935953227fe5004fb8b24ce60",
-      "from": "github:orbitdb/orbit-db",
+      "version": "github:orbitdb/orbit-db#a8e097b4f8ef3271de86ab3212df8e7e19ac7389",
       "requires": {
-        "ipfs-pubsub-1on1": "~0.0.4",
-        "logplease": "^1.2.14",
-        "multihashes": "^0.4.12",
-        "orbit-db-cache": "~0.2.2",
-        "orbit-db-counterstore": "~1.4.0",
-        "orbit-db-docstore": "~1.4.3",
-        "orbit-db-eventstore": "~1.4.0",
-        "orbit-db-feedstore": "~1.4.0",
-        "orbit-db-keystore": "~0.1.0",
-        "orbit-db-kvstore": "~1.4.0",
-        "orbit-db-pubsub": "~0.5.5",
-        "orbit-db-store": "~2.5.2"
+        "ipfs-pubsub-1on1": "0.0.4",
+        "logplease": "1.2.14",
+        "multihashes": "0.4.13",
+        "orbit-db-cache": "0.2.3",
+        "orbit-db-counterstore": "1.4.0",
+        "orbit-db-docstore": "1.4.3",
+        "orbit-db-eventstore": "1.4.0",
+        "orbit-db-feedstore": "1.4.0",
+        "orbit-db-keystore": "0.1.0",
+        "orbit-db-kvstore": "1.4.0",
+        "orbit-db-pubsub": "0.5.5",
+        "orbit-db-store": "2.5.2"
       }
     },
     "orbit-db-cache": {
@@ -5099,10 +5047,10 @@
       "resolved": "https://registry.npmjs.org/orbit-db-cache/-/orbit-db-cache-0.2.3.tgz",
       "integrity": "sha512-b7ic6K1cc7N9x9jfiplL9TKA3b/eJUmvZE2CvdB2wX/sVE/zmLr2TOlnLjteeBQXmlop4jrnqy+PGl8bYHUPkA==",
       "requires": {
-        "level-js": "~2.2.4",
-        "leveldown": "^1.9.0",
-        "logplease": "^1.2.14",
-        "mkdirp": "^0.5.1"
+        "level-js": "2.2.4",
+        "leveldown": "1.9.0",
+        "logplease": "1.2.14",
+        "mkdirp": "0.5.1"
       },
       "dependencies": {
         "abstract-leveldown": {
@@ -5110,7 +5058,7 @@
           "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
           "integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
           "requires": {
-            "xtend": "~3.0.0"
+            "xtend": "3.0.0"
           },
           "dependencies": {
             "xtend": {
@@ -5125,12 +5073,12 @@
           "resolved": "https://registry.npmjs.org/level-js/-/level-js-2.2.4.tgz",
           "integrity": "sha1-vAVfQYBjXUSJtWHJSG+jcOjBFpc=",
           "requires": {
-            "abstract-leveldown": "~0.12.0",
-            "idb-wrapper": "^1.5.0",
-            "isbuffer": "~0.0.0",
-            "ltgt": "^2.1.2",
-            "typedarray-to-buffer": "~1.0.0",
-            "xtend": "~2.1.2"
+            "abstract-leveldown": "0.12.4",
+            "idb-wrapper": "1.7.2",
+            "isbuffer": "0.0.0",
+            "ltgt": "2.2.1",
+            "typedarray-to-buffer": "1.0.4",
+            "xtend": "2.1.2"
           }
         },
         "leveldown": {
@@ -5138,11 +5086,11 @@
           "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-1.9.0.tgz",
           "integrity": "sha512-3MwcrnCUIuFiKp/jSrG1UqDTV4k1yH8f5HH6T9dpqCKG+lRxcfo2KwAqbzTT+TTKfCbaATeHMy9mm1y6sI3ZvA==",
           "requires": {
-            "abstract-leveldown": "~2.7.0",
-            "bindings": "~1.3.0",
-            "fast-future": "~1.0.2",
-            "nan": "~2.7.0",
-            "prebuild-install": "^2.1.0"
+            "abstract-leveldown": "2.7.2",
+            "bindings": "1.3.0",
+            "fast-future": "1.0.2",
+            "nan": "2.7.0",
+            "prebuild-install": "2.5.3"
           },
           "dependencies": {
             "abstract-leveldown": {
@@ -5150,7 +5098,7 @@
               "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
               "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
               "requires": {
-                "xtend": "~4.0.0"
+                "xtend": "4.0.1"
               }
             },
             "xtend": {
@@ -5170,21 +5118,21 @@
           "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.3.tgz",
           "integrity": "sha512-/rI36cN2g7vDQnKWN8Uzupi++KjyqS9iS+/fpwG4Ea8d0Pip0PQ5bshUNzVwt+/D2MRfhVAplYMMvWLqWrCF/g==",
           "requires": {
-            "detect-libc": "^1.0.3",
-            "expand-template": "^1.0.2",
+            "detect-libc": "1.0.3",
+            "expand-template": "1.1.1",
             "github-from-package": "0.0.0",
-            "minimist": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "node-abi": "^2.2.0",
-            "noop-logger": "^0.1.1",
-            "npmlog": "^4.0.1",
-            "os-homedir": "^1.0.1",
-            "pump": "^2.0.1",
-            "rc": "^1.1.6",
-            "simple-get": "^2.7.0",
-            "tar-fs": "^1.13.0",
-            "tunnel-agent": "^0.6.0",
-            "which-pm-runs": "^1.0.0"
+            "minimist": "1.2.0",
+            "mkdirp": "0.5.1",
+            "node-abi": "2.4.3",
+            "noop-logger": "0.1.1",
+            "npmlog": "4.1.2",
+            "os-homedir": "1.0.2",
+            "pump": "2.0.1",
+            "rc": "1.2.8",
+            "simple-get": "2.8.1",
+            "tar-fs": "1.16.3",
+            "tunnel-agent": "0.6.0",
+            "which-pm-runs": "1.0.0"
           }
         },
         "pump": {
@@ -5192,8 +5140,8 @@
           "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
           "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
           "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
           }
         },
         "typedarray-to-buffer": {
@@ -5206,7 +5154,7 @@
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
           "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
           "requires": {
-            "object-keys": "~0.4.0"
+            "object-keys": "0.4.0"
           }
         }
       }
@@ -5216,8 +5164,8 @@
       "resolved": "https://registry.npmjs.org/orbit-db-counterstore/-/orbit-db-counterstore-1.4.0.tgz",
       "integrity": "sha512-L7GBp1q1LawWi398wHqMgN6LwdGssB1GomwsSCeSHTMO0iPPUNe7S+lsAuJ+ZWc07qH0wvHnWkd6CC2JJaLOIA==",
       "requires": {
-        "crdts": "~0.1.2",
-        "orbit-db-store": "~2.5.0"
+        "crdts": "0.1.5",
+        "orbit-db-store": "2.5.2"
       }
     },
     "orbit-db-docstore": {
@@ -5225,8 +5173,8 @@
       "resolved": "https://registry.npmjs.org/orbit-db-docstore/-/orbit-db-docstore-1.4.3.tgz",
       "integrity": "sha512-iDSXL3V71qK7CuS3VBEHPMXubCFr77VkpqEu14K5jTLRAYZdL7496VTZX8gf8KSJkYQF+nqz4WHJmqoxh1XU0A==",
       "requires": {
-        "orbit-db-store": "~2.5.0",
-        "p-map": "~1.1.1"
+        "orbit-db-store": "2.5.2",
+        "p-map": "1.1.1"
       },
       "dependencies": {
         "p-map": {
@@ -5241,7 +5189,7 @@
       "resolved": "https://registry.npmjs.org/orbit-db-eventstore/-/orbit-db-eventstore-1.4.0.tgz",
       "integrity": "sha512-VifnAIK8B1JP/hZmn6k0MPk5UzdmoVSsMlvjhPl+d13ZIucAN/tlP5Arn1udXnQVCg9wm3zRD3Ks+wQxE0LJLA==",
       "requires": {
-        "orbit-db-store": "~2.5.0"
+        "orbit-db-store": "2.5.2"
       }
     },
     "orbit-db-feedstore": {
@@ -5249,7 +5197,7 @@
       "resolved": "https://registry.npmjs.org/orbit-db-feedstore/-/orbit-db-feedstore-1.4.0.tgz",
       "integrity": "sha512-+VQrei6OMPsz9fHXBtqkqYrlJXJuBbFEpMTYR69uWlDd48z5DrLN1pdRq9ND5YeQmGBhdVR1Pm5zOIQNfYw37A==",
       "requires": {
-        "orbit-db-eventstore": "~1.4.0"
+        "orbit-db-eventstore": "1.4.0"
       }
     },
     "orbit-db-keystore": {
@@ -5257,9 +5205,9 @@
       "resolved": "https://registry.npmjs.org/orbit-db-keystore/-/orbit-db-keystore-0.1.0.tgz",
       "integrity": "sha512-LG3jlhPL6PcsInKoXuDqLyhXmulBA9EHAdavrfFv16za7HZ7oWIkr/e7DzEgH7Lb9bWdclsi2Misxj+9lLwKbA==",
       "requires": {
-        "elliptic": "^6.4.0",
-        "mkdirp": "^0.5.1",
-        "node-localstorage": "^1.3.0"
+        "elliptic": "6.4.0",
+        "mkdirp": "0.5.1",
+        "node-localstorage": "1.3.1"
       }
     },
     "orbit-db-kvstore": {
@@ -5267,7 +5215,7 @@
       "resolved": "https://registry.npmjs.org/orbit-db-kvstore/-/orbit-db-kvstore-1.4.0.tgz",
       "integrity": "sha512-4qhyJf6N2LK8/tUWWoN0svUGEA4GLujMXxZAPFjP6UdH3XM70bvPw4k6DjIST/PQcYZqKf3BbYoIKRSiLeEJPg==",
       "requires": {
-        "orbit-db-store": "~2.5.0"
+        "orbit-db-store": "2.5.2"
       }
     },
     "orbit-db-pubsub": {
@@ -5275,9 +5223,9 @@
       "resolved": "https://registry.npmjs.org/orbit-db-pubsub/-/orbit-db-pubsub-0.5.5.tgz",
       "integrity": "sha512-o8vATfW7sJ61OrsmaGd2myXdbAc64Plap4Cs4vQ5wlpt4rM74tSo5FY6hIfySei5MuCbxph2y6dDILMhWdcMng==",
       "requires": {
-        "ipfs-pubsub-peer-monitor": "~0.0.5",
-        "logplease": "~1.2.14",
-        "p-series": "^1.1.0"
+        "ipfs-pubsub-peer-monitor": "0.0.8",
+        "logplease": "1.2.14",
+        "p-series": "1.1.0"
       }
     },
     "orbit-db-store": {
@@ -5285,10 +5233,10 @@
       "resolved": "https://registry.npmjs.org/orbit-db-store/-/orbit-db-store-2.5.2.tgz",
       "integrity": "sha512-cMGdbeWeIPSrV7thi1zeajyrkmPU0q7F0gfpoGN1ucJUzZSmULPCr+/rU+32Bj/eb4VRg9STEF5H5AXqcB5eHA==",
       "requires": {
-        "ipfs-log": "~4.1.0",
-        "logplease": "^1.2.14",
-        "p-each-series": "^1.0.0",
-        "readable-stream": "~2.3.5"
+        "ipfs-log": "4.1.2",
+        "logplease": "1.2.14",
+        "p-each-series": "1.0.0",
+        "readable-stream": "2.3.6"
       }
     },
     "os-homedir": {
@@ -5301,9 +5249,9 @@
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
       "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
       "requires": {
-        "execa": "^0.7.0",
-        "lcid": "^1.0.0",
-        "mem": "^1.1.0"
+        "execa": "0.7.0",
+        "lcid": "1.0.0",
+        "mem": "1.1.0"
       }
     },
     "os-tmpdir": {
@@ -5316,7 +5264,7 @@
       "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
       "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
       "requires": {
-        "p-reduce": "^1.0.0"
+        "p-reduce": "1.0.0"
       }
     },
     "p-finally": {
@@ -5334,7 +5282,7 @@
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
       "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
       "requires": {
-        "p-try": "^2.0.0"
+        "p-try": "2.0.0"
       }
     },
     "p-locate": {
@@ -5342,7 +5290,7 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "requires": {
-        "p-limit": "^2.0.0"
+        "p-limit": "2.0.0"
       }
     },
     "p-map": {
@@ -5355,7 +5303,7 @@
       "resolved": "https://registry.npmjs.org/p-map-series/-/p-map-series-1.0.0.tgz",
       "integrity": "sha1-v5j+V1cFZYqeE1G++4WuTB8Hvco=",
       "requires": {
-        "p-reduce": "^1.0.0"
+        "p-reduce": "1.0.0"
       }
     },
     "p-queue": {
@@ -5373,8 +5321,8 @@
       "resolved": "https://registry.npmjs.org/p-series/-/p-series-1.1.0.tgz",
       "integrity": "sha512-356covArc9UCfj2twY/sxCJKGMzzO+pJJtucizsPC6aS1xKSTBc9PQrQhvFR3+7F+fa2KBKdJjdIcv6NEWDcIQ==",
       "requires": {
-        "@sindresorhus/is": "^0.7.0",
-        "p-reduce": "^1.0.0"
+        "@sindresorhus/is": "0.7.0",
+        "p-reduce": "1.0.0"
       }
     },
     "p-try": {
@@ -5392,10 +5340,10 @@
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "requires": {
-        "got": "^6.7.1",
-        "registry-auth-token": "^3.0.1",
-        "registry-url": "^3.0.3",
-        "semver": "^5.1.0"
+        "got": "6.7.1",
+        "registry-auth-token": "3.3.2",
+        "registry-url": "3.1.0",
+        "semver": "5.5.0"
       }
     },
     "parse-json": {
@@ -5403,8 +5351,8 @@
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "requires": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
+        "error-ex": "1.3.2",
+        "json-parse-better-errors": "1.0.2"
       }
     },
     "parseqs": {
@@ -5412,7 +5360,7 @@
       "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
       "requires": {
-        "better-assert": "~1.0.0"
+        "better-assert": "1.0.2"
       }
     },
     "parseuri": {
@@ -5420,7 +5368,7 @@
       "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
       "requires": {
-        "better-assert": "~1.0.0"
+        "better-assert": "1.0.2"
       }
     },
     "path-exists": {
@@ -5448,7 +5396,7 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
       "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
       "requires": {
-        "pify": "^3.0.0"
+        "pify": "3.0.0"
       }
     },
     "peer-book": {
@@ -5456,9 +5404,9 @@
       "resolved": "https://registry.npmjs.org/peer-book/-/peer-book-0.8.0.tgz",
       "integrity": "sha512-0An5viX2NnYeaqmwe2Vpzl03K9yxJ08mrktzkCPJyyd6rO4xz6QV2JK2Ku2vTHATP8Ag0ambxvr0QbrkT4UCYA==",
       "requires": {
-        "bs58": "^4.0.1",
-        "peer-id": "^0.10.7",
-        "peer-info": "^0.14.1"
+        "bs58": "4.0.1",
+        "peer-id": "0.10.7",
+        "peer-info": "0.14.1"
       },
       "dependencies": {
         "libp2p-crypto": {
@@ -5466,19 +5414,18 @@
           "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
           "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
           "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.1.1",
-            "bs58": "^4.0.1",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.7",
-            "node-forge": "^0.7.1",
-            "pem-jwk": "^1.5.1",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+            "asn1.js": "5.0.1",
+            "async": "2.6.1",
+            "browserify-aes": "1.2.0",
+            "bs58": "4.0.1",
+            "keypair": "1.0.1",
+            "libp2p-crypto-secp256k1": "0.2.2",
+            "multihashing-async": "0.4.8",
+            "node-forge": "0.7.5",
+            "pem-jwk": "1.5.1",
+            "protons": "1.0.1",
+            "rsa-pem-to-jwk": "1.1.3",
+            "tweetnacl": "1.0.0"
           }
         },
         "multihashing-async": {
@@ -5486,12 +5433,12 @@
           "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
           "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
           "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
+            "async": "2.6.1",
+            "blakejs": "1.1.0",
+            "js-sha3": "0.7.0",
+            "multihashes": "0.4.13",
+            "murmurhash3js": "3.0.1",
+            "nodeify": "1.0.1"
           }
         },
         "peer-id": {
@@ -5499,10 +5446,10 @@
           "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
           "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
           "requires": {
-            "async": "^2.6.0",
-            "libp2p-crypto": "~0.12.1",
-            "lodash": "^4.17.5",
-            "multihashes": "~0.4.13"
+            "async": "2.6.1",
+            "libp2p-crypto": "0.12.1",
+            "lodash": "4.17.10",
+            "multihashes": "0.4.13"
           }
         }
       }
@@ -5512,10 +5459,10 @@
       "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.11.0.tgz",
       "integrity": "sha512-C/lRJk4CWIgOdKvfO572NvHbPcUwe49I6G0toIhDB5tCohqv/qzy0uBcAK9Ww8TvYI6U4J3C8ACShV9fWjNU4w==",
       "requires": {
-        "async": "^2.6.1",
-        "libp2p-crypto": "~0.13.0",
-        "lodash": "^4.17.10",
-        "multihashes": "~0.4.13"
+        "async": "2.6.1",
+        "libp2p-crypto": "0.13.0",
+        "lodash": "4.17.10",
+        "multihashes": "0.4.13"
       }
     },
     "peer-info": {
@@ -5523,10 +5470,10 @@
       "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.14.1.tgz",
       "integrity": "sha512-I9K+q7sisU0gg5ej6ekbhgolwlcm1tc2wDtLmumptoLYx0DkIT8WVHtgoTnupYwRRqcYADtwddFdiXfb8QFqzg==",
       "requires": {
-        "lodash.uniqby": "^4.7.0",
-        "mafmt": "^6.0.0",
-        "multiaddr": "^4.0.0",
-        "peer-id": "~0.10.7"
+        "lodash.uniqby": "4.7.0",
+        "mafmt": "6.0.0",
+        "multiaddr": "4.0.0",
+        "peer-id": "0.10.7"
       },
       "dependencies": {
         "libp2p-crypto": {
@@ -5534,19 +5481,18 @@
           "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
           "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
           "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.1.1",
-            "bs58": "^4.0.1",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.7",
-            "node-forge": "^0.7.1",
-            "pem-jwk": "^1.5.1",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+            "asn1.js": "5.0.1",
+            "async": "2.6.1",
+            "browserify-aes": "1.2.0",
+            "bs58": "4.0.1",
+            "keypair": "1.0.1",
+            "libp2p-crypto-secp256k1": "0.2.2",
+            "multihashing-async": "0.4.8",
+            "node-forge": "0.7.5",
+            "pem-jwk": "1.5.1",
+            "protons": "1.0.1",
+            "rsa-pem-to-jwk": "1.1.3",
+            "tweetnacl": "1.0.0"
           }
         },
         "multiaddr": {
@@ -5554,14 +5500,14 @@
           "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-4.0.0.tgz",
           "integrity": "sha512-zUatrOCfBd/tJNOSoJ10d2EI2FDXB9PyPZhqUMdXE9mOyR3C+HLuOjga2Ga/eChwvEHIpTYRMoIKF2Nv7af2qQ==",
           "requires": {
-            "bs58": "^4.0.1",
-            "class-is": "^1.1.0",
-            "ip": "^1.1.5",
-            "ip-address": "^5.8.9",
-            "lodash.filter": "^4.6.0",
-            "lodash.map": "^4.6.0",
-            "varint": "^5.0.0",
-            "xtend": "^4.0.1"
+            "bs58": "4.0.1",
+            "class-is": "1.1.0",
+            "ip": "1.1.5",
+            "ip-address": "5.8.9",
+            "lodash.filter": "4.6.0",
+            "lodash.map": "4.6.0",
+            "varint": "5.0.0",
+            "xtend": "4.0.1"
           }
         },
         "multihashing-async": {
@@ -5569,12 +5515,12 @@
           "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
           "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
           "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
+            "async": "2.6.1",
+            "blakejs": "1.1.0",
+            "js-sha3": "0.7.0",
+            "multihashes": "0.4.13",
+            "murmurhash3js": "3.0.1",
+            "nodeify": "1.0.1"
           }
         },
         "peer-id": {
@@ -5582,10 +5528,10 @@
           "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
           "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
           "requires": {
-            "async": "^2.6.0",
-            "libp2p-crypto": "~0.12.1",
-            "lodash": "^4.17.5",
-            "multihashes": "~0.4.13"
+            "async": "2.6.1",
+            "libp2p-crypto": "0.12.1",
+            "lodash": "4.17.10",
+            "multihashes": "0.4.13"
           }
         }
       }
@@ -5603,9 +5549,9 @@
           "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
           "integrity": "sha1-KBuj7B8kSP52X5Kk7s+IP+E2S1Q=",
           "requires": {
-            "bn.js": "^1.0.0",
-            "inherits": "^2.0.1",
-            "minimalistic-assert": "^1.0.0"
+            "bn.js": "1.3.0",
+            "inherits": "2.0.3",
+            "minimalistic-assert": "1.0.1"
           }
         },
         "bn.js": {
@@ -5621,11 +5567,11 @@
       "resolved": "https://registry.npmjs.org/pez/-/pez-2.1.5.tgz",
       "integrity": "sha1-XsLMYlAMw+tCNtSkFM9aF7XrUAc=",
       "requires": {
-        "b64": "3.x.x",
-        "boom": "5.x.x",
-        "content": "3.x.x",
-        "hoek": "4.x.x",
-        "nigel": "2.x.x"
+        "b64": "3.0.3",
+        "boom": "5.2.0",
+        "content": "3.0.7",
+        "hoek": "4.2.1",
+        "nigel": "2.0.2"
       },
       "dependencies": {
         "boom": {
@@ -5633,7 +5579,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "4.2.1"
           }
         },
         "hoek": {
@@ -5653,7 +5599,7 @@
       "resolved": "https://registry.npmjs.org/pipe-args/-/pipe-args-1.3.0.tgz",
       "integrity": "sha1-CbM3Ga7w3ecOBs+14jxc287ebys=",
       "requires": {
-        "ramda": "^0.23.0"
+        "ramda": "0.23.0"
       }
     },
     "podium": {
@@ -5661,9 +5607,9 @@
       "resolved": "https://registry.npmjs.org/podium/-/podium-1.3.0.tgz",
       "integrity": "sha512-ZIujqk1pv8bRZNVxwwwq0BhXilZ2udycQT3Kp8ah3f3TcTmVg7ILJsv/oLf47gRa2qeiP584lNq+pfvS9U3aow==",
       "requires": {
-        "hoek": "4.x.x",
-        "items": "2.x.x",
-        "joi": "10.x.x"
+        "hoek": "4.2.1",
+        "items": "2.1.1",
+        "joi": "10.6.0"
       },
       "dependencies": {
         "hoek": {
@@ -5676,10 +5622,10 @@
           "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
           "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
           "requires": {
-            "hoek": "4.x.x",
-            "isemail": "2.x.x",
-            "items": "2.x.x",
-            "topo": "2.x.x"
+            "hoek": "4.2.1",
+            "isemail": "2.2.1",
+            "items": "2.1.1",
+            "topo": "2.0.2"
           }
         }
       }
@@ -5689,21 +5635,21 @@
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-4.0.0.tgz",
       "integrity": "sha512-7tayxeYboJX0RbVzdnKyGl2vhQRWr6qfClEXDhOkXjuaOKCw2q8aiuFhONRYVsG/czia7KhpykIlI2S2VaPunA==",
       "requires": {
-        "detect-libc": "^1.0.3",
-        "expand-template": "^1.0.2",
+        "detect-libc": "1.0.3",
+        "expand-template": "1.1.1",
         "github-from-package": "0.0.0",
-        "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "node-abi": "^2.2.0",
-        "noop-logger": "^0.1.1",
-        "npmlog": "^4.0.1",
-        "os-homedir": "^1.0.1",
-        "pump": "^2.0.1",
-        "rc": "^1.1.6",
-        "simple-get": "^2.7.0",
-        "tar-fs": "^1.13.0",
-        "tunnel-agent": "^0.6.0",
-        "which-pm-runs": "^1.0.0"
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "node-abi": "2.4.3",
+        "noop-logger": "0.1.1",
+        "npmlog": "4.1.2",
+        "os-homedir": "1.0.2",
+        "pump": "2.0.1",
+        "rc": "1.2.8",
+        "simple-get": "2.8.1",
+        "tar-fs": "1.16.3",
+        "tunnel-agent": "0.6.0",
+        "which-pm-runs": "1.0.0"
       },
       "dependencies": {
         "pump": {
@@ -5711,8 +5657,8 @@
           "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
           "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
           "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
           }
         }
       }
@@ -5748,7 +5694,7 @@
       "integrity": "sha512-itUicyrq3Rko56v3ovQAMYwxEouK7lIylp26bjnlt1b/3fzn783riZnZn432I4udYmPsRgNx1F/u9RFvLyH7zA==",
       "optional": true,
       "requires": {
-        "tdigest": "^0.1.1"
+        "tdigest": "0.1.1"
       }
     },
     "prometheus-gc-stats": {
@@ -5757,8 +5703,8 @@
       "integrity": "sha1-RxO8Xp9znuCahslkAU37zk/VAAM=",
       "optional": true,
       "requires": {
-        "gc-stats": "^1.0.0",
-        "optional": "^0.1.3"
+        "gc-stats": "1.2.0",
+        "optional": "0.1.4"
       }
     },
     "promise": {
@@ -5766,7 +5712,7 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-1.3.0.tgz",
       "integrity": "sha1-5cyaTIJ45GZP/twBx9qEhCsEAXU=",
       "requires": {
-        "is-promise": "~1"
+        "is-promise": "1.0.1"
       }
     },
     "promise-timeout": {
@@ -5789,10 +5735,10 @@
       "resolved": "https://registry.npmjs.org/protons/-/protons-1.0.1.tgz",
       "integrity": "sha512-+0ZKnfVs+4c43tbAQ5j0Mck8wPcLnlxUYzKQoB4iDW4ocdXGnN4P+0dDbgX1FTpoY9+7P2Tn2scJyHHqj+S/lQ==",
       "requires": {
-        "protocol-buffers-schema": "^3.3.1",
-        "safe-buffer": "^5.1.1",
-        "signed-varint": "^2.0.1",
-        "varint": "^5.0.0"
+        "protocol-buffers-schema": "3.3.2",
+        "safe-buffer": "5.1.2",
+        "signed-varint": "2.0.1",
+        "varint": "5.0.0"
       }
     },
     "prr": {
@@ -5815,7 +5761,7 @@
       "resolved": "https://registry.npmjs.org/pull-batch/-/pull-batch-1.0.0.tgz",
       "integrity": "sha1-OopwhNsOmDxcWb8OB0qkHnU/Alg=",
       "requires": {
-        "pull-through": "^1.0.18"
+        "pull-through": "1.0.18"
       }
     },
     "pull-block": {
@@ -5823,7 +5769,7 @@
       "resolved": "https://registry.npmjs.org/pull-block/-/pull-block-1.4.0.tgz",
       "integrity": "sha512-nqrFveL9SWdpM9FDkgUVifhbH/dgtK65Pmwa/rrdvB9avE32uWXb1uiemxczfrkqZaG4XVc139KdqfyvPoraoA==",
       "requires": {
-        "pull-through": "^1.0.18"
+        "pull-through": "1.0.18"
       }
     },
     "pull-cat": {
@@ -5846,7 +5792,7 @@
       "resolved": "https://registry.npmjs.org/pull-file/-/pull-file-1.1.0.tgz",
       "integrity": "sha1-HdmHYF1jV6DSPB5Lgm95FaIVEpw=",
       "requires": {
-        "pull-utf8-decoder": "^1.0.2"
+        "pull-utf8-decoder": "1.0.2"
       }
     },
     "pull-handshake": {
@@ -5854,10 +5800,10 @@
       "resolved": "https://registry.npmjs.org/pull-handshake/-/pull-handshake-1.1.4.tgz",
       "integrity": "sha1-YACg/QGIhM39c3JU+Mxgqypjd5E=",
       "requires": {
-        "pull-cat": "^1.1.9",
-        "pull-pair": "~1.1.0",
-        "pull-pushable": "^2.0.0",
-        "pull-reader": "^1.2.3"
+        "pull-cat": "1.1.11",
+        "pull-pair": "1.1.0",
+        "pull-pushable": "2.2.0",
+        "pull-reader": "1.3.1"
       }
     },
     "pull-length-prefixed": {
@@ -5865,10 +5811,10 @@
       "resolved": "https://registry.npmjs.org/pull-length-prefixed/-/pull-length-prefixed-1.3.1.tgz",
       "integrity": "sha512-Ho0KoVKOILITGPusghadRVcUzflFHAHcv1Hvi/OkUSJLkGK2LNmVjsmIaJbWkizI//okIj2n376JyTFwCWdsYA==",
       "requires": {
-        "pull-pushable": "^2.0.1",
-        "pull-reader": "^1.3.0",
-        "safe-buffer": "^5.0.1",
-        "varint": "^5.0.0"
+        "pull-pushable": "2.2.0",
+        "pull-reader": "1.3.1",
+        "safe-buffer": "5.1.2",
+        "varint": "5.0.0"
       }
     },
     "pull-many": {
@@ -5876,7 +5822,7 @@
       "resolved": "https://registry.npmjs.org/pull-many/-/pull-many-1.0.8.tgz",
       "integrity": "sha1-Pa3ZttFWxUVyG9qNAAPdjqoGKT4=",
       "requires": {
-        "pull-stream": "^3.4.5"
+        "pull-stream": "3.6.8"
       }
     },
     "pull-ndjson": {
@@ -5884,9 +5830,9 @@
       "resolved": "https://registry.npmjs.org/pull-ndjson/-/pull-ndjson-0.1.1.tgz",
       "integrity": "sha1-gx4GutmqbFxevBKol+Og4V1J4H4=",
       "requires": {
-        "pull-split": "^0.2.0",
-        "pull-stream": "^3.4.5",
-        "pull-stringify": "^1.2.2"
+        "pull-split": "0.2.0",
+        "pull-stream": "3.6.8",
+        "pull-stringify": "1.2.2"
       }
     },
     "pull-pair": {
@@ -5899,7 +5845,7 @@
       "resolved": "https://registry.npmjs.org/pull-paramap/-/pull-paramap-1.2.2.tgz",
       "integrity": "sha1-UaQZPOnI1yFdla2tReK824STsjo=",
       "requires": {
-        "looper": "^4.0.0"
+        "looper": "4.0.0"
       },
       "dependencies": {
         "looper": {
@@ -5929,8 +5875,8 @@
       "resolved": "https://registry.npmjs.org/pull-sort/-/pull-sort-1.0.1.tgz",
       "integrity": "sha1-qKsMcMhvRTQ8mszJOfxCdprT3G0=",
       "requires": {
-        "pull-defer": "^0.2.2",
-        "pull-stream": "^3.6.0"
+        "pull-defer": "0.2.2",
+        "pull-stream": "3.6.8"
       }
     },
     "pull-split": {
@@ -5938,7 +5884,7 @@
       "resolved": "https://registry.npmjs.org/pull-split/-/pull-split-0.2.0.tgz",
       "integrity": "sha1-mW0ohTEFIgmoMTiK0NKB3zyCN5Y=",
       "requires": {
-        "pull-through": "~1.0.6"
+        "pull-through": "1.0.18"
       }
     },
     "pull-stream": {
@@ -5961,7 +5907,7 @@
       "resolved": "https://registry.npmjs.org/pull-through/-/pull-through-1.0.18.tgz",
       "integrity": "sha1-jdYjFCY+Wc9Qlur7sSeitu8xBzU=",
       "requires": {
-        "looper": "~3.0.0"
+        "looper": "3.0.0"
       }
     },
     "pull-traverse": {
@@ -5979,9 +5925,9 @@
       "resolved": "https://registry.npmjs.org/pull-write/-/pull-write-1.1.4.tgz",
       "integrity": "sha1-3d6jFJO0j2douEooHQHrO1Mf4Lg=",
       "requires": {
-        "looper": "^4.0.0",
-        "pull-cat": "^1.1.11",
-        "pull-stream": "^3.4.5"
+        "looper": "4.0.0",
+        "pull-cat": "1.1.11",
+        "pull-stream": "3.6.8"
       },
       "dependencies": {
         "looper": {
@@ -5996,9 +5942,9 @@
       "resolved": "https://registry.npmjs.org/pull-ws/-/pull-ws-3.3.1.tgz",
       "integrity": "sha512-kJodbLQT+oKjcRIQO+vQNw6xWBuEo7Kxp51VMOvb6cvPvHYA+aNLzm+NmkB/5dZwbuTRYGMal9QPvH52tzM1ZA==",
       "requires": {
-        "relative-url": "^1.0.2",
-        "safe-buffer": "^5.1.1",
-        "ws": "^1.1.0"
+        "relative-url": "1.0.2",
+        "safe-buffer": "5.1.2",
+        "ws": "1.1.5"
       }
     },
     "pull-zip": {
@@ -6011,8 +5957,8 @@
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
+        "end-of-stream": "1.4.1",
+        "once": "1.4.0"
       }
     },
     "punycode": {
@@ -6025,7 +5971,7 @@
       "resolved": "https://registry.npmjs.org/pushdata-bitcoin/-/pushdata-bitcoin-1.0.1.tgz",
       "integrity": "sha1-FZMdPNlnreUiBvUjqnMxrvfUOvc=",
       "requires": {
-        "bitcoin-ops": "^1.3.0"
+        "bitcoin-ops": "1.4.1"
       }
     },
     "qs": {
@@ -6043,7 +5989,7 @@
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
       "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "requires": {
-        "safe-buffer": "^5.1.0"
+        "safe-buffer": "5.1.2"
       }
     },
     "rc": {
@@ -6051,10 +5997,10 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "requires": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
+        "deep-extend": "0.6.0",
+        "ini": "1.3.5",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
       }
     },
     "read-pkg": {
@@ -6062,9 +6008,9 @@
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
       "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
       "requires": {
-        "load-json-file": "^4.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^3.0.0"
+        "load-json-file": "4.0.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "3.0.0"
       }
     },
     "read-pkg-up": {
@@ -6072,8 +6018,8 @@
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
       "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
       "requires": {
-        "find-up": "^3.0.0",
-        "read-pkg": "^3.0.0"
+        "find-up": "3.0.0",
+        "read-pkg": "3.0.0"
       }
     },
     "readable-stream": {
@@ -6081,13 +6027,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
       }
     },
     "readable-stream-node-to-web": {
@@ -6100,8 +6046,8 @@
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
       "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
       "requires": {
-        "rc": "^1.1.6",
-        "safe-buffer": "^5.0.1"
+        "rc": "1.2.8",
+        "safe-buffer": "5.1.2"
       }
     },
     "registry-url": {
@@ -6109,7 +6055,7 @@
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "requires": {
-        "rc": "^1.0.1"
+        "rc": "1.2.8"
       }
     },
     "relative-url": {
@@ -6138,7 +6084,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.1.2"
       }
     },
     "ripemd160": {
@@ -6146,8 +6092,8 @@
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
+        "hash-base": "3.0.4",
+        "inherits": "2.0.3"
       }
     },
     "rlp": {
@@ -6155,7 +6101,7 @@
       "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.1.0.tgz",
       "integrity": "sha512-93U7IKH5j7nmXFVg19MeNBGzQW5uXW1pmCuKY8veeKIhYTE32C2d0mOegfiIAfXcHOKJjjPlJisn8iHDF5AezA==",
       "requires": {
-        "safe-buffer": "^5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "rsa-pem-to-jwk": {
@@ -6163,7 +6109,7 @@
       "resolved": "https://registry.npmjs.org/rsa-pem-to-jwk/-/rsa-pem-to-jwk-1.1.3.tgz",
       "integrity": "sha1-JF52vbfnI0z+58oDLTG1TDj6uY4=",
       "requires": {
-        "object-assign": "^2.0.0",
+        "object-assign": "2.1.1",
         "rsa-unpack": "0.0.6"
       }
     },
@@ -6172,7 +6118,7 @@
       "resolved": "https://registry.npmjs.org/rsa-unpack/-/rsa-unpack-0.0.6.tgz",
       "integrity": "sha1-9Q69VqYoN45jHylxYQJs6atO3bo=",
       "requires": {
-        "optimist": "~0.3.5"
+        "optimist": "0.3.7"
       }
     },
     "safe-buffer": {
@@ -6185,7 +6131,7 @@
       "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.1.tgz",
       "integrity": "sha1-YS2hyWRz+gLczaktzVtKsWSmdyo=",
       "requires": {
-        "truncate-utf8-bytes": "^1.0.0"
+        "truncate-utf8-bytes": "1.0.2"
       }
     },
     "secp256k1": {
@@ -6193,14 +6139,14 @@
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.0.tgz",
       "integrity": "sha512-e5QIJl8W7Y4tT6LHffVcZAxJjvpgE5Owawv6/XCYPQljE9aP2NFFddQ8OYMKhdLshNu88FfL3qCN3/xYkXGRsA==",
       "requires": {
-        "bindings": "^1.2.1",
-        "bip66": "^1.1.3",
-        "bn.js": "^4.11.3",
-        "create-hash": "^1.1.2",
-        "drbg.js": "^1.0.1",
-        "elliptic": "^6.2.3",
-        "nan": "^2.2.1",
-        "safe-buffer": "^5.1.0"
+        "bindings": "1.3.0",
+        "bip66": "1.1.5",
+        "bn.js": "4.11.8",
+        "create-hash": "1.2.0",
+        "drbg.js": "1.0.1",
+        "elliptic": "6.4.0",
+        "nan": "2.10.0",
+        "safe-buffer": "5.1.2"
       }
     },
     "semaphore": {
@@ -6218,7 +6164,7 @@
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "requires": {
-        "semver": "^5.0.3"
+        "semver": "5.5.0"
       }
     },
     "set-blocking": {
@@ -6236,8 +6182,8 @@
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "shebang-command": {
@@ -6245,7 +6191,7 @@
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
@@ -6258,7 +6204,7 @@
       "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.12.tgz",
       "integrity": "sha512-sw0knB/ioTu/jVYgJz1IP1b5uhPZtZYwQ9ir/EqXZHI4+Jh8rzzGLM3LKptGHBKoDsgTBDfr4yCRNUX7hEIksQ==",
       "requires": {
-        "nanoid": "^1.0.7"
+        "nanoid": "1.1.0"
       }
     },
     "shot": {
@@ -6266,8 +6212,8 @@
       "resolved": "https://registry.npmjs.org/shot/-/shot-3.4.2.tgz",
       "integrity": "sha1-Hlw/bysmZJrcQvfrNQIUpaApHWc=",
       "requires": {
-        "hoek": "4.x.x",
-        "joi": "10.x.x"
+        "hoek": "4.2.1",
+        "joi": "10.6.0"
       },
       "dependencies": {
         "hoek": {
@@ -6280,10 +6226,10 @@
           "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
           "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
           "requires": {
-            "hoek": "4.x.x",
-            "isemail": "2.x.x",
-            "items": "2.x.x",
-            "topo": "2.x.x"
+            "hoek": "4.2.1",
+            "isemail": "2.2.1",
+            "items": "2.1.1",
+            "topo": "2.0.2"
           }
         }
       }
@@ -6298,7 +6244,7 @@
       "resolved": "https://registry.npmjs.org/signed-varint/-/signed-varint-2.0.1.tgz",
       "integrity": "sha1-UKmYnafJjCxh2tEZvJdHDvhSgSk=",
       "requires": {
-        "varint": "~5.0.0"
+        "varint": "5.0.0"
       }
     },
     "simple-concat": {
@@ -6311,9 +6257,9 @@
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
       "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
       "requires": {
-        "decompress-response": "^3.3.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
+        "decompress-response": "3.3.0",
+        "once": "1.4.0",
+        "simple-concat": "1.0.0"
       }
     },
     "simple-peer": {
@@ -6321,11 +6267,11 @@
       "resolved": "https://registry.npmjs.org/simple-peer/-/simple-peer-9.1.2.tgz",
       "integrity": "sha512-MUWWno5o5cvISKOH4pYQ18PQJLpDaNWoKUbrPPKuspCLCkkh+zhtuQyTE8h2U2Ags+/OUN5wnUe92+9B8/Sm2Q==",
       "requires": {
-        "debug": "^3.1.0",
-        "get-browser-rtc": "^1.0.0",
-        "inherits": "^2.0.1",
-        "randombytes": "^2.0.3",
-        "readable-stream": "^2.3.4"
+        "debug": "3.1.0",
+        "get-browser-rtc": "1.0.2",
+        "inherits": "2.0.3",
+        "randombytes": "2.0.6",
+        "readable-stream": "2.3.6"
       }
     },
     "slide": {
@@ -6343,12 +6289,12 @@
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.1.1.tgz",
       "integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
       "requires": {
-        "debug": "~3.1.0",
-        "engine.io": "~3.2.0",
-        "has-binary2": "~1.0.2",
-        "socket.io-adapter": "~1.1.0",
+        "debug": "3.1.0",
+        "engine.io": "3.2.0",
+        "has-binary2": "1.0.3",
+        "socket.io-adapter": "1.1.1",
         "socket.io-client": "2.1.1",
-        "socket.io-parser": "~3.2.0"
+        "socket.io-parser": "3.2.0"
       }
     },
     "socket.io-adapter": {
@@ -6365,15 +6311,15 @@
         "base64-arraybuffer": "0.1.5",
         "component-bind": "1.0.0",
         "component-emitter": "1.2.1",
-        "debug": "~3.1.0",
-        "engine.io-client": "~3.2.0",
-        "has-binary2": "~1.0.2",
+        "debug": "3.1.0",
+        "engine.io-client": "3.2.1",
+        "has-binary2": "1.0.3",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "object-component": "0.0.3",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "socket.io-parser": "~3.2.0",
+        "socket.io-parser": "3.2.0",
         "to-array": "0.1.4"
       }
     },
@@ -6383,7 +6329,7 @@
       "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
       "requires": {
         "component-emitter": "1.2.1",
-        "debug": "~3.1.0",
+        "debug": "3.1.0",
         "isarray": "2.0.1"
       },
       "dependencies": {
@@ -6400,9 +6346,9 @@
       "integrity": "sha512-lcC2se3iAS33xYGnTDSzYW9P4RPVEgcqACCH7Mawy+2go0Wmx3y72PXGv7KI6Vz1YFcOz7np58FqOnZ/iUCbdg==",
       "requires": {
         "data-queue": "0.0.3",
-        "debug": "^3.1.0",
-        "pull-stream": "^3.6.2",
-        "uuid": "^3.2.1"
+        "debug": "3.1.0",
+        "pull-stream": "3.6.8",
+        "uuid": "3.3.2"
       }
     },
     "sparse-array": {
@@ -6415,8 +6361,8 @@
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -6429,8 +6375,8 @@
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-exceptions": "2.1.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -6443,7 +6389,7 @@
       "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
       "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
       "requires": {
-        "through": "2"
+        "through": "2.3.8"
       }
     },
     "split2": {
@@ -6451,7 +6397,7 @@
       "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
       "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
       "requires": {
-        "through2": "^2.0.2"
+        "through2": "2.0.3"
       }
     },
     "sprintf-js": {
@@ -6469,12 +6415,12 @@
       "resolved": "https://registry.npmjs.org/statehood/-/statehood-5.0.3.tgz",
       "integrity": "sha512-YrPrCt10t3ImH/JMO5szSwX7sCm8HoqVl3VFLOa9EZ1g/qJx/ZmMhN+2uzPPB/vaU6hpkJpXxcBWsgIkkG+MXA==",
       "requires": {
-        "boom": "5.x.x",
-        "cryptiles": "3.x.x",
-        "hoek": "4.x.x",
-        "iron": "4.x.x",
-        "items": "2.x.x",
-        "joi": "10.x.x"
+        "boom": "5.2.0",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.1",
+        "iron": "4.0.5",
+        "items": "2.1.1",
+        "joi": "10.6.0"
       },
       "dependencies": {
         "boom": {
@@ -6482,7 +6428,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "4.2.1"
           }
         },
         "hoek": {
@@ -6495,10 +6441,10 @@
           "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
           "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
           "requires": {
-            "hoek": "4.x.x",
-            "isemail": "2.x.x",
-            "items": "2.x.x",
-            "topo": "2.x.x"
+            "hoek": "4.2.1",
+            "isemail": "2.2.1",
+            "items": "2.1.1",
+            "topo": "2.0.2"
           }
         }
       }
@@ -6508,11 +6454,11 @@
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
       "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
       "requires": {
-        "builtin-status-codes": "^3.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.3.6",
-        "to-arraybuffer": "^1.0.0",
-        "xtend": "^4.0.0"
+        "builtin-status-codes": "3.0.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "to-arraybuffer": "1.0.1",
+        "xtend": "4.0.1"
       }
     },
     "stream-shift": {
@@ -6525,8 +6471,8 @@
       "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.2.tgz",
       "integrity": "sha1-dXYJrhzr0zx0MtSvvjH/eGULnd4=",
       "requires": {
-        "looper": "^3.0.0",
-        "pull-stream": "^3.2.3"
+        "looper": "3.0.0",
+        "pull-stream": "3.6.8"
       }
     },
     "streamifier": {
@@ -6544,9 +6490,9 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
       }
     },
     "string_decoder": {
@@ -6554,7 +6500,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.2"
       }
     },
     "strip-ansi": {
@@ -6562,7 +6508,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-bom": {
@@ -6593,11 +6539,11 @@
       "resolved": "https://registry.npmjs.org/subtext/-/subtext-5.0.0.tgz",
       "integrity": "sha512-2nXG1G1V+K64Z20cQII7k0s38J2DSycMXBLMAk9RXUFG0uAkAbLSVoa88croX9VhTdBCJbLAe9g6LmzKwpJhhQ==",
       "requires": {
-        "boom": "5.x.x",
-        "content": "3.x.x",
-        "hoek": "4.x.x",
-        "pez": "2.x.x",
-        "wreck": "12.x.x"
+        "boom": "5.2.0",
+        "content": "3.0.7",
+        "hoek": "4.2.1",
+        "pez": "2.1.5",
+        "wreck": "12.5.1"
       },
       "dependencies": {
         "boom": {
@@ -6605,7 +6551,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "4.2.1"
           }
         },
         "hoek": {
@@ -6620,7 +6566,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
       "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
       "requires": {
-        "has-flag": "^3.0.0"
+        "has-flag": "3.0.0"
       }
     },
     "tar-fs": {
@@ -6628,10 +6574,10 @@
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
       "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
       "requires": {
-        "chownr": "^1.0.1",
-        "mkdirp": "^0.5.1",
-        "pump": "^1.0.0",
-        "tar-stream": "^1.1.2"
+        "chownr": "1.0.1",
+        "mkdirp": "0.5.1",
+        "pump": "1.0.3",
+        "tar-stream": "1.6.1"
       },
       "dependencies": {
         "pump": {
@@ -6639,8 +6585,8 @@
           "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
           "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
           "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
           }
         }
       }
@@ -6650,13 +6596,13 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
       "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
       "requires": {
-        "bl": "^1.0.0",
-        "buffer-alloc": "^1.1.0",
-        "end-of-stream": "^1.0.0",
-        "fs-constants": "^1.0.0",
-        "readable-stream": "^2.3.0",
-        "to-buffer": "^1.1.0",
-        "xtend": "^4.0.0"
+        "bl": "1.2.2",
+        "buffer-alloc": "1.2.0",
+        "end-of-stream": "1.4.1",
+        "fs-constants": "1.0.0",
+        "readable-stream": "2.3.6",
+        "to-buffer": "1.1.1",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "bl": {
@@ -6664,8 +6610,8 @@
           "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
           "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
           "requires": {
-            "readable-stream": "^2.3.5",
-            "safe-buffer": "^5.1.1"
+            "readable-stream": "2.3.6",
+            "safe-buffer": "5.1.2"
           }
         }
       }
@@ -6683,8 +6629,8 @@
       "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
       "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
       "requires": {
-        "os-tmpdir": "^1.0.0",
-        "rimraf": "~2.2.6"
+        "os-tmpdir": "1.0.2",
+        "rimraf": "2.2.8"
       },
       "dependencies": {
         "rimraf": {
@@ -6699,7 +6645,7 @@
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
       "requires": {
-        "execa": "^0.7.0"
+        "execa": "0.7.0"
       }
     },
     "through": {
@@ -6712,8 +6658,8 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "requires": {
-        "readable-stream": "^2.1.5",
-        "xtend": "~4.0.1"
+        "readable-stream": "2.3.6",
+        "xtend": "4.0.1"
       }
     },
     "thunky": {
@@ -6726,7 +6672,7 @@
       "resolved": "https://registry.npmjs.org/time-cache/-/time-cache-0.3.0.tgz",
       "integrity": "sha1-7Q388P2kXNyV+9YB/agw6/G9XYs=",
       "requires": {
-        "lodash.throttle": "^4.1.1"
+        "lodash.throttle": "4.1.1"
       }
     },
     "timed-out": {
@@ -6764,7 +6710,7 @@
       "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
       "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "4.2.1"
       },
       "dependencies": {
         "hoek": {
@@ -6784,7 +6730,7 @@
       "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
       "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
       "requires": {
-        "utf8-byte-length": "^1.0.1"
+        "utf8-byte-length": "1.0.4"
       }
     },
     "tunnel-agent": {
@@ -6792,7 +6738,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "tweetnacl": {
@@ -6810,7 +6756,7 @@
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "requires": {
-        "is-typedarray": "^1.0.0"
+        "is-typedarray": "1.0.0"
       }
     },
     "typeforce": {
@@ -6828,7 +6774,7 @@
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "requires": {
-        "crypto-random-string": "^1.0.0"
+        "crypto-random-string": "1.0.0"
       }
     },
     "unzip-response": {
@@ -6841,16 +6787,16 @@
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
       "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
       "requires": {
-        "boxen": "^1.2.1",
-        "chalk": "^2.0.1",
-        "configstore": "^3.0.0",
-        "import-lazy": "^2.1.0",
-        "is-ci": "^1.0.10",
-        "is-installed-globally": "^0.1.0",
-        "is-npm": "^1.0.0",
-        "latest-version": "^3.0.0",
-        "semver-diff": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
+        "boxen": "1.3.0",
+        "chalk": "2.4.1",
+        "configstore": "3.1.2",
+        "import-lazy": "2.1.0",
+        "is-ci": "1.1.0",
+        "is-installed-globally": "0.1.0",
+        "is-npm": "1.0.0",
+        "latest-version": "3.1.0",
+        "semver-diff": "2.1.0",
+        "xdg-basedir": "3.0.0"
       }
     },
     "url-parse-lax": {
@@ -6858,7 +6804,7 @@
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "requires": {
-        "prepend-http": "^1.0.1"
+        "prepend-http": "1.0.4"
       }
     },
     "utf8-byte-length": {
@@ -6896,8 +6842,8 @@
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
       "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
       "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
+        "spdx-correct": "3.0.0",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "varint": {
@@ -6910,7 +6856,7 @@
       "resolved": "https://registry.npmjs.org/varint-decoder/-/varint-decoder-0.1.1.tgz",
       "integrity": "sha1-YT1i8HHX51dqIO/RbvTB4zWg3f0=",
       "requires": {
-        "varint": "^5.0.0"
+        "varint": "5.0.0"
       }
     },
     "varuint-bitcoin": {
@@ -6918,7 +6864,7 @@
       "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.0.tgz",
       "integrity": "sha512-jCEPG+COU/1Rp84neKTyDJQr478/hAfVp5xxYn09QEH0yBjbmPeMfuuQIrp+BUD83hybtYZKhr5elV3bvdV1bA==",
       "requires": {
-        "safe-buffer": "^5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "vise": {
@@ -6926,7 +6872,7 @@
       "resolved": "https://registry.npmjs.org/vise/-/vise-2.0.2.tgz",
       "integrity": "sha1-awjo+0y3bjpQzW3Q7DczjoEaDTk=",
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "4.2.1"
       },
       "dependencies": {
         "hoek": {
@@ -6936,20 +6882,12 @@
         }
       }
     },
-    "webcrypto-shim": {
-      "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
-      "from": "github:dignifiedquire/webcrypto-shim#master"
-    },
-    "webrtcsupport": {
-      "version": "github:ipfs/webrtcsupport#0669f576582c53a3a42aa5ac014fcc5966809615",
-      "from": "github:ipfs/webrtcsupport"
-    },
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "which-module": {
@@ -6967,7 +6905,7 @@
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "requires": {
-        "string-width": "^1.0.2 || 2"
+        "string-width": "1.0.2"
       }
     },
     "widest-line": {
@@ -6975,7 +6913,7 @@
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
       "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
       "requires": {
-        "string-width": "^2.1.1"
+        "string-width": "2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -6993,8 +6931,8 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -7002,7 +6940,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -7012,7 +6950,7 @@
       "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
       "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
       "requires": {
-        "bs58check": "<3.0.0"
+        "bs58check": "2.1.1"
       }
     },
     "wordwrap": {
@@ -7025,8 +6963,8 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
       }
     },
     "wrappy": {
@@ -7039,8 +6977,8 @@
       "resolved": "https://registry.npmjs.org/wreck/-/wreck-12.5.1.tgz",
       "integrity": "sha512-l5DUGrc+yDyIflpty1x9XuMj1ehVjC/dTbF3/BasOO77xk0EdEa4M/DuOY8W88MQDAD0fEDqyjc8bkIMHd2E9A==",
       "requires": {
-        "boom": "5.x.x",
-        "hoek": "4.x.x"
+        "boom": "5.2.0",
+        "hoek": "4.2.1"
       },
       "dependencies": {
         "boom": {
@@ -7048,7 +6986,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "4.2.1"
           }
         },
         "hoek": {
@@ -7063,9 +7001,9 @@
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.2"
+        "graceful-fs": "4.1.11",
+        "imurmurhash": "0.1.4",
+        "signal-exit": "3.0.2"
       }
     },
     "ws": {
@@ -7073,8 +7011,8 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
       "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
       "requires": {
-        "options": ">=0.0.5",
-        "ultron": "1.0.x"
+        "options": "0.0.6",
+        "ultron": "1.0.2"
       }
     },
     "xdg-basedir": {
@@ -7117,18 +7055,18 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
       "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
       "requires": {
-        "cliui": "^4.0.0",
-        "decamelize": "^1.1.1",
-        "find-up": "^2.1.0",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^2.0.0",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^2.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^3.2.1",
-        "yargs-parser": "^9.0.2"
+        "cliui": "4.1.0",
+        "decamelize": "1.2.0",
+        "find-up": "2.1.0",
+        "get-caller-file": "1.0.3",
+        "os-locale": "2.1.0",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "2.1.1",
+        "which-module": "2.0.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "9.0.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -7146,7 +7084,7 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -7159,8 +7097,8 @@
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
           }
         },
         "p-limit": {
@@ -7168,7 +7106,7 @@
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
           "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "requires": {
-            "p-try": "^1.0.0"
+            "p-try": "1.0.0"
           }
         },
         "p-locate": {
@@ -7176,7 +7114,7 @@
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "requires": {
-            "p-limit": "^1.1.0"
+            "p-limit": "1.3.0"
           }
         },
         "p-try": {
@@ -7189,8 +7127,8 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -7198,7 +7136,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         },
         "y18n": {
@@ -7211,7 +7149,7 @@
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
           "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
           "requires": {
-            "camelcase": "^4.1.0"
+            "camelcase": "4.1.0"
           }
         }
       }
@@ -7221,7 +7159,7 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
       "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
       "requires": {
-        "camelcase": "^4.1.0"
+        "camelcase": "4.1.0"
       }
     },
     "yargs-promise": {
@@ -7239,12 +7177,12 @@
       "resolved": "https://registry.npmjs.org/zcash-bitcore-lib/-/zcash-bitcore-lib-0.13.20-rc3.tgz",
       "integrity": "sha1-gToPVtz4t2vBQplRvqbRI2xQcAg=",
       "requires": {
-        "bn.js": "=2.0.4",
-        "bs58": "=2.0.0",
-        "buffer-compare": "=1.0.0",
-        "elliptic": "=3.0.3",
-        "inherits": "=2.0.1",
-        "lodash": "=3.10.1"
+        "bn.js": "2.0.4",
+        "bs58": "2.0.0",
+        "buffer-compare": "1.0.0",
+        "elliptic": "3.0.3",
+        "inherits": "2.0.1",
+        "lodash": "3.10.1"
       },
       "dependencies": {
         "bn.js": {
@@ -7267,10 +7205,10 @@
           "resolved": "http://registry.npmjs.org/elliptic/-/elliptic-3.0.3.tgz",
           "integrity": "sha1-hlybQgv75VAGuflp+XoNLESWZZU=",
           "requires": {
-            "bn.js": "^2.0.0",
-            "brorand": "^1.0.1",
-            "hash.js": "^1.0.0",
-            "inherits": "^2.0.1"
+            "bn.js": "2.0.4",
+            "brorand": "1.0.5",
+            "hash.js": "1.0.3",
+            "inherits": "2.0.1"
           },
           "dependencies": {
             "brorand": {
@@ -7283,7 +7221,7 @@
               "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
               "integrity": "sha1-EzL/ABVsCg/92CNgE9B7d6BFFXM=",
               "requires": {
-                "inherits": "^2.0.1"
+                "inherits": "2.0.1"
               }
             }
           }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "express": "^4.16.3",
+    "stoppable": "^1.0.6",
     "ipfs": "~0.30.1",
     "logplease": "~1.2.14",
     "orbit-db": "orbitdb/orbit-db",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "node": ">=8.0.0"
   },
   "dependencies": {
+    "express": "^4.16.3",
     "ipfs": "~0.30.1",
     "logplease": "~1.2.14",
     "orbit-db": "orbitdb/orbit-db",

--- a/src/commands/daemon.js
+++ b/src/commands/daemon.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const path = require('path')
+const server = require('../lib/orbit-db-http-server/server.js')
+const outputTimer = require('../lib/output-timer')
+const exitOnError = require('../exit-on-error')
+
+/* Export as Yargs command */
+exports.command = 'daemon'
+exports.desc = 'Start a orbitdb daemon'
+
+exports.builder = (yargs) => {
+  return yargs
+    .usage(`Usage: $0 daemon`)
+    .example('\n$0 daemon',
+             '\nOrbitDB server started at http://host:37373/')
+}
+
+exports.handler = (argv) => {
+  const startTime = new Date().getTime()
+  argv = Object.assign({}, argv, { create: false, localOnly: true })
+  server().then(null)
+}

--- a/src/lib/orbit-db-http-server/routes/add.js
+++ b/src/lib/orbit-db-http-server/routes/add.js
@@ -1,0 +1,54 @@
+const add = async (req, res) => {
+  // TODO: validate database type to be 'log' or 'feed'
+  try {
+    // Get the database address from the request
+    const address = req.params[0]
+
+    // Get the entry to add
+    const data = req.body
+
+    // Check if the incoming request is a stream
+    const isStream = req.headers['content-type'] === 'application/octet-stream'
+
+    if (!data && !isStream)
+      throw new Error('Database entry was undefined')
+
+    // Open the requested database
+    const db = await req.orbitdb.open(address, {
+      create: false,
+      sync: false,
+    })
+
+    // Load the database
+    await db.load()
+
+    // Handle incoming stream
+    if (isStream) {
+      let addedHashes = []
+      req.setEncoding('utf8')
+
+      req.on('data', async (chunk) => { 
+        const hash = await db.add(chunk)
+        addedHashes.push(hash)
+      })
+
+      req.on('end', function() {
+        res.send(addedHashes)
+      })
+    } else {
+      // Query for all results
+      const hash = await db.add(data)
+
+      // Get the added entry
+      const entry = db._oplog.get(hash)
+
+      // Return the hash and the entry
+      res.send(entry)
+    }
+  } catch (e) {
+    // TODO: return 404 if the database doesn't exist
+    res.status(500).send({ error: e.toString() })
+  }
+}
+
+module.exports = add

--- a/src/lib/orbit-db-http-server/routes/create.js
+++ b/src/lib/orbit-db-http-server/routes/create.js
@@ -1,0 +1,20 @@
+const create = async (req, res) => {
+  try {
+    // Get the name and type from the request
+    const { name, type } = req.params
+
+    // Create the database
+    const db = await req.orbitdb.create(name, type, { write: ['*'] })
+
+    // Return databse info as the result
+    res.send({
+      name: db.dbname,
+      type: db.type,
+      address: db.address.toString(),
+    })
+  } catch (e) {
+    res.status(500).send({ error: e.toString() })
+  }
+}
+
+module.exports = create

--- a/src/lib/orbit-db-http-server/routes/get.js
+++ b/src/lib/orbit-db-http-server/routes/get.js
@@ -1,0 +1,47 @@
+const get = async (req, res) => {
+  try {
+    // Get the database address from the request
+    const address = req.params[0]
+
+    // Get params on how we should output the results
+    const shouldStream = req.query.live || false
+
+    // Set the limit on how many entries we should return in the result
+    const limit = req.query.limit || -1
+
+    // Open the requested database
+    const db = await req.orbitdb.open(address, {
+      create: false,
+      sync: true,
+      localOnly: req.query.live ? !req.query.live : true,
+    })
+
+    // Load the database
+    await db.load()
+
+    const query = () => db.iterator({ limit: limit }).collect()
+
+    // Loop if we're streaming the results
+    if (shouldStream) {
+      const queryAndRespond = () => {
+        res.write(JSON.stringify({
+          result: query()
+        }))
+      }
+      db.events.on('replicated', queryAndRespond)
+      db.events.on('write', queryAndRespond)
+      res.on('end', () => console.log("FINISHED!"))
+      queryAndRespond()
+    } else {
+      // Return the results
+      res.send({
+        result: query()
+      })
+    }
+  } catch (e) {
+    // TODO: return 404 if the database doesn't exist
+    res.status(500).send({ error: e.toString() })
+  }
+}
+
+module.exports = get

--- a/src/lib/orbit-db-http-server/server.js
+++ b/src/lib/orbit-db-http-server/server.js
@@ -1,0 +1,93 @@
+const express = require('express')
+const bodyParser = require('body-parser')
+
+// Config and start script
+const config = require('../../config')
+const startIpfs = require('../../start-ipfs.js')
+const OrbitDB = require('orbit-db')
+const stoppable = require('stoppable')
+
+// Route handlers
+const create = require('./routes/create')
+const get = require('./routes/get')
+const add = require('./routes/add')
+
+// Logging
+const Logger = require('logplease')
+const logger = Logger.create("orbit-db-http-server", { color: Logger.Colors.Yellow })
+Logger.setLogLevel('ERROR')
+
+// Default port and host for simplicity
+const defaultPort = 37373
+const defaultHost = "localhost"
+// Start
+const startHttpServer = async (options = {}) => {
+  // Bind to a specific host if given
+  const host = options.host || defaultHost
+  // Make sure we have a port
+  const port = options.port || defaultPort
+
+  logger.log(`Start http-server in port ${port}`)
+
+  // Create the server
+  const app = express()
+
+  return new Promise((resolve, reject) => {
+    // Start the HTTP server
+    let server = app.listen({ port: port, host: host }, async () => {
+      server = stoppable(server, 1000)
+      // Start IPFS and OrbitDB
+      const ipfs = await startIpfs(config.ipfsConfig)
+      const peerId = await ipfs.config.get('Identity.PeerID')
+      // We need to pass the IPFS ID since we're not starting IPFS
+      const directory = process.env.ORBITDB_PATH || config.defaultDatabaseDir
+      const orbitdb = new OrbitDB(ipfs, directory, { peerId: peerId })
+
+      // Add a stop function that resets the server state after the server was closed
+      const stopFunc = server.stop
+      server.stop = () => {
+        return new Promise(async (resolve) => {
+          await orbitdb.disconnect()
+          ipfs.stop(() => {
+            delete server.state
+            stopFunc(() => resolve())
+          })
+        })
+      }
+      const err = false
+      if (err){
+        reject(server)
+      }
+
+      const logRequest = (req, res, next) => {
+        logger.debug(`[${req.method}] ${req.url}`)
+        req.logger = logger
+        next()
+      }
+
+      const useOrbitDB = (req, res, next) => {
+        req.orbitdb = orbitdb
+        next()
+      }
+
+      // Setup routes
+      app.use(logRequest) // Logging
+      app.use(bodyParser.text({ type: 'text/plain' }))
+      app.use(useOrbitDB) // Pass OrbitDB instance to the route handlers
+      app.get('/', (req, res) => res.send('OrbitDB')) // Default index page
+      app.get('/orbitdb/*', get) // Query a database
+      app.get('/create/:type/:name', create) // Create a new databse
+      app.post('/add/orbitdb/*', add) // Add an entry to a databse
+
+      // Started
+      const startedText = `OrbitDB server started at http://${server.address().address}:${port}/`
+      logger.log(startedText)
+      console.log(startedText)
+
+      // Return the server
+      resolve(server)
+    })
+  })
+}
+
+module.exports = startHttpServer


### PR DESCRIPTION
Copied files `server.js` `add.js` `create.js` `get.js` from 3c691c032a047e99237af24af6956b9068c314e6 branch of orbit-db-http-server at https://github.com/haadcode/orbit-db-http-server.git

Added a new file in commands that run the daemon. This currently runs in the foreground and can be canceled with CTL + C, also hard coded the port and host to remove unneeded files.

-added the files that the original PR was missing.